### PR TITLE
Improve thumnail compression

### DIFF
--- a/src/services/upload/thumbnailService.ts
+++ b/src/services/upload/thumbnailService.ts
@@ -7,8 +7,8 @@ import FFmpegService from 'services/ffmpegService';
 const THUMBNAIL_HEIGHT = 720;
 const MIN_COMPRESSION_PERCENTAGE_SIZE_DIFF = 10;
 export const MAX_THUMBNAIL_SIZE = 100 * 1024;
-const MIN_COMPRESSION_QUALITY = 0.7;
-const MAX_COMPRESSION_QUALITY = 0.5;
+const MIN_QUALITY = 0.5;
+const MAX_QUALITY = 0.7;
 
 const WAIT_TIME_THUMBNAIL_GENERATION = 10 * 1000;
 
@@ -175,7 +175,7 @@ export async function generateVideoThumbnail(file: globalThis.File) {
 async function thumbnailCanvasToBlob(canvas: HTMLCanvasElement) {
     let thumbnailBlob: Blob = null;
     let prevSize = Number.MAX_SAFE_INTEGER;
-    let quality = MIN_COMPRESSION_QUALITY;
+    let quality = MAX_QUALITY;
 
     do {
         if (thumbnailBlob) {
@@ -193,7 +193,7 @@ async function thumbnailCanvasToBlob(canvas: HTMLCanvasElement) {
         thumbnailBlob = thumbnailBlob ?? new Blob([]);
         quality -= 0.1;
     } while (
-        quality > MAX_COMPRESSION_QUALITY &&
+        quality >= MIN_QUALITY &&
         thumbnailBlob.size > MAX_THUMBNAIL_SIZE &&
         percentageSizeDiff(thumbnailBlob.size, prevSize) >=
             MIN_COMPRESSION_PERCENTAGE_SIZE_DIFF


### PR DESCRIPTION
## Description

Compress thumbnails till the compression size is not less than MIN_COMPRESSION_SIZE_DIFF, currrently set at 10%

or the thumbnail size comes the acceptable  MAX_THUMBNAIL size range

## Test Plan

- [x] checked loop breaks if MIN_COMPRESSION_SIZE_DIFF condition not meant
