### PR TITLE
ffmpeg thumbnail dimension change

### DIFF
--- a/src/services/ffmpegService.ts
+++ b/src/services/ffmpegService.ts
@@ -63,7 +63,7 @@ async function generateThumbnailHelper(ffmpeg: FFmpeg, file: File) {
                     '-vframes',
                     '1',
                     '-vf',
-                    'scale=512:512',
+                    'scale=-1:720',
                     thumbFileName
                 );
                 thumb = ffmpeg.FS('readFile', thumbFileName);


### PR DESCRIPTION
## Description

make ffmpeg generated thumbnail have height of 720 and maintain aspect ratio

changed the resolution of thumbnail generated by ffmpeg to have height 720, else the compression step would be stretching a 512 * 512  to 720 * 720

also fix ffmpeg in-memory file names -toString `()` was missing 


## Test Plan
- confirmed generated file has height of 720
- confirmed logs to see correct file name are used
