### PR TITLE
don't report thumbnail upto size of 150KB

### DIFF
--- a/src/services/upload/thumbnailService.ts
+++ b/src/services/upload/thumbnailService.ts
@@ -234,7 +234,7 @@ async function thumbnailCanvasToBlob(canvas: HTMLCanvasElement) {
         percentageSizeDiff(thumbnailBlob.size, prevSize) >=
             MIN_COMPRESSION_PERCENTAGE_SIZE_DIFF
     );
-    if (thumbnailBlob.size > 2 * MAX_THUMBNAIL_SIZE) {
+    if (thumbnailBlob.size > 1.5 * MAX_THUMBNAIL_SIZE) {
         logError(
             Error('thumbnail_too_large'),
             'thumbnail greater than max limit',

--- a/src/services/upload/thumbnailService.ts
+++ b/src/services/upload/thumbnailService.ts
@@ -234,7 +234,7 @@ async function thumbnailCanvasToBlob(canvas: HTMLCanvasElement) {
         percentageSizeDiff(thumbnailBlob.size, prevSize) >=
             MIN_COMPRESSION_PERCENTAGE_SIZE_DIFF
     );
-    if (thumbnailBlob.size > MAX_THUMBNAIL_SIZE) {
+    if (thumbnailBlob.size > 2 * MAX_THUMBNAIL_SIZE) {
         logError(
             Error('thumbnail_too_large'),
             'thumbnail greater than max limit',


### PR DESCRIPTION
## Description
getting sentry log for thumbnail just greater than 100KB( like 100.58 KB)

updated the report large thumbnails only on condition that they are greater than 150KB  

<img width="989" alt="image" src="https://user-images.githubusercontent.com/46242073/205500171-15939089-62cb-41b2-8358-4f54bbe4cd52.png">
