### PR TITLE
move uploaderName to pubMagicMetadata

### DIFF
--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -467,11 +467,13 @@ export default function Uploader(props: Props) {
         try {
             addLogLine('user retrying failed  upload');
             const filesWithCollections =
-                await uploadManager.getFailedFilesWithCollections();
+                uploadManager.getFailedFilesWithCollections();
+            const uploaderName = uploadManager.getUploaderName();
             await preUploadAction();
             await uploadManager.queueFilesForUpload(
                 filesWithCollections.files,
-                filesWithCollections.collections
+                filesWithCollections.collections,
+                uploaderName
             );
         } catch (err) {
             showUserFacingError(err.message);

--- a/src/services/upload/fileService.ts
+++ b/src/services/upload/fileService.ts
@@ -22,6 +22,7 @@ import {
     getUint8ArrayView,
 } from '../readerService';
 import { generateThumbnail } from './thumbnailService';
+import { EncryptedMagicMetadataCore } from 'types/magicMetadata';
 
 const EDITED_FILE_SUFFIX = '-edited';
 
@@ -110,6 +111,16 @@ export async function encryptFile(
         const { file: encryptedMetadata }: EncryptionResult =
             await worker.encryptMetadata(file.metadata, fileKey);
 
+        const { file: encryptedPubMagicMetadataData }: EncryptionResult =
+            await worker.encryptMetadata(file.pubMagicMetadata.data, fileKey);
+
+        const encryptedPubMagicMetadata: EncryptedMagicMetadataCore = {
+            version: file.pubMagicMetadata.version,
+            count: file.pubMagicMetadata.count,
+            data: encryptedPubMagicMetadataData.encryptedData as unknown as string,
+            header: encryptedPubMagicMetadataData.decryptionHeader,
+        };
+
         const encryptedKey: B64EncryptionResult = await worker.encryptToB64(
             fileKey,
             encryptionKey
@@ -120,6 +131,7 @@ export async function encryptFile(
                 file: encryptedFiledata,
                 thumbnail: encryptedThumbnail,
                 metadata: encryptedMetadata,
+                pubMagicMetadata: encryptedPubMagicMetadata,
                 localID: file.localID,
             },
             fileKey: encryptedKey,

--- a/src/services/upload/magicMetadataService.ts
+++ b/src/services/upload/magicMetadataService.ts
@@ -1,0 +1,17 @@
+import {
+    FilePublicMagicMetadataProps,
+    FilePublicMagicMetadata,
+} from 'types/file';
+import { NEW_FILE_MAGIC_METADATA } from 'types/magicMetadata';
+import { updateMagicMetadataProps } from 'utils/magicMetadata';
+
+export async function constructPublicMagicMetadata(
+    publicMagicMetadataProps: FilePublicMagicMetadataProps
+): Promise<FilePublicMagicMetadata> {
+    const pubMagicMetadata = await updateMagicMetadataProps(
+        NEW_FILE_MAGIC_METADATA,
+        null,
+        publicMagicMetadataProps
+    );
+    return pubMagicMetadata;
+}

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -539,11 +539,15 @@ class UploadManager {
         uploadCancelService.requestUploadCancelation();
     }
 
-    async getFailedFilesWithCollections() {
+    getFailedFilesWithCollections() {
         return {
             files: this.failedFiles,
             collections: [...this.collections.values()],
         };
+    }
+
+    getUploaderName() {
+        return this.uploaderName;
     }
 
     private updateExistingFiles(decryptedFile: EnteFile) {

--- a/src/services/upload/uploadService.ts
+++ b/src/services/upload/uploadService.ts
@@ -35,6 +35,8 @@ import { uploadStreamUsingMultipart } from './multiPartUploadService';
 import UIService from './uiService';
 import { USE_CF_PROXY } from 'constants/upload';
 import publicUploadHttpClient from './publicUploadHttpClient';
+import { constructPublicMagicMetadata } from './magicMetadataService';
+import { FilePublicMagicMetadataProps } from 'types/file';
 
 class UploadService {
     private uploadURLs: UploadURL[] = [];
@@ -142,6 +144,12 @@ class UploadService {
         return clusterLivePhotoFiles(mediaFiles);
     }
 
+    constructPublicMagicMetadata(
+        publicMagicMetadataProps: FilePublicMagicMetadataProps
+    ) {
+        return constructPublicMagicMetadata(publicMagicMetadataProps);
+    }
+
     async encryptAsset(
         worker: any,
         file: FileWithMetadata,
@@ -203,6 +211,7 @@ class UploadService {
                     objectKey: thumbnailObjectKey,
                 },
                 metadata: file.metadata,
+                pubMagicMetadata: file.pubMagicMetadata,
             };
             return backupedFile;
         } catch (e) {

--- a/src/types/file/index.ts
+++ b/src/types/file/index.ts
@@ -20,6 +20,7 @@ export interface FilePublicMagicMetadataProps {
     editedTime?: number;
     editedName?: string;
     caption?: string;
+    uploaderName?: string;
 }
 
 export interface FilePublicMagicMetadata

--- a/src/types/magicMetadata/index.ts
+++ b/src/types/magicMetadata/index.ts
@@ -21,7 +21,7 @@ export enum SUB_TYPE {
 }
 
 export const NEW_FILE_MAGIC_METADATA: MagicMetadataCore = {
-    version: 0,
+    version: 1,
     data: {},
     header: null,
     count: 0,

--- a/src/types/upload/index.ts
+++ b/src/types/upload/index.ts
@@ -1,6 +1,7 @@
 import { FILE_TYPE } from 'constants/file';
 import { Collection } from 'types/collection';
-import { fileAttribute } from 'types/file';
+import { fileAttribute, FilePublicMagicMetadata } from 'types/file';
+import { EncryptedMagicMetadataCore } from 'types/magicMetadata';
 
 export interface DataStream {
     stream: ReadableStream<Uint8Array>;
@@ -27,7 +28,6 @@ export interface Metadata {
     hash?: string;
     imageHash?: string;
     videoHash?: string;
-    uploaderName?: string;
 }
 
 export interface Location {
@@ -120,6 +120,7 @@ export interface FileWithMetadata
     extends Omit<FileInMemory, 'hasStaticThumbnail'> {
     metadata: Metadata;
     localID: number;
+    pubMagicMetadata: FilePublicMagicMetadata;
 }
 
 export interface EncryptedFile {
@@ -130,6 +131,7 @@ export interface ProcessedFile {
     file: fileAttribute;
     thumbnail: fileAttribute;
     metadata: fileAttribute;
+    pubMagicMetadata: EncryptedMagicMetadataCore;
     localID: number;
 }
 export interface BackupedFile extends Omit<ProcessedFile, 'localID'> {}


### PR DESCRIPTION
## Description

^ title 

- also fixed the retry upload  in the public upload 

## Test Plan

- [x]  checked file pubMagicMetadata is properly set and present in the synced file 
- [x] tested normal upload for regressions 
- [x] normal metadata doesn't have uploaderName anymore 
