### PR TITLE
remove the use of elp extension

### DIFF
--- a/src/services/upload/livePhotoService.ts
+++ b/src/services/upload/livePhotoService.ts
@@ -77,7 +77,7 @@ export function getLivePhotoSize(livePhotoAssets: LivePhotoAssets) {
 }
 
 export function getLivePhotoName(livePhotoAssets: LivePhotoAssets) {
-    return splitFilenameAndExtension(livePhotoAssets.image.name)[0];
+    return livePhotoAssets.image.name;
 }
 
 export async function readLivePhoto(

--- a/src/services/upload/livePhotoService.ts
+++ b/src/services/upload/livePhotoService.ts
@@ -26,8 +26,6 @@ interface LivePhotoIdentifier {
     size: number;
 }
 
-const ENTE_LIVE_PHOTO_FORMAT = 'elp';
-
 const UNDERSCORE_THREE = '_3';
 
 const UNDERSCORE = '_';
@@ -79,9 +77,7 @@ export function getLivePhotoSize(livePhotoAssets: LivePhotoAssets) {
 }
 
 export function getLivePhotoName(livePhotoAssets: LivePhotoAssets) {
-    return `${
-        splitFilenameAndExtension(livePhotoAssets.image.name)[0]
-    }.${ENTE_LIVE_PHOTO_FORMAT}`;
+    return splitFilenameAndExtension(livePhotoAssets.image.name)[0];
 }
 
 export async function readLivePhoto(

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -562,7 +562,7 @@ const englishConstants = {
     ),
 
     LIVE_PHOTOS_DETECTED:
-        'The photo and video files from your Live Photos have been merged into a single ELP file',
+        'The photo and video files from your Live Photos have been merged into a single file',
 
     RETRY_FAILED: 'Retry failed uploads',
     FAILED_UPLOADS: 'Failed uploads ',


### PR DESCRIPTION
## Description

- use image extension as live photo extension
- and remove mention of ELP in live photos are being merged help text in the upload dialog

<img width="615" alt="image" src="https://user-images.githubusercontent.com/46242073/208066735-ed010e43-2dc6-436f-bdbd-bd0535dbdd01.png">


## Test Plan

tested locally 
