### PR TITLE
fix unhandled expection on file search

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -187,7 +187,13 @@ const PhotoFrame = ({
                 }
                 return false;
             });
-    }, [files, deletedFileIds, search, activeCollection]);
+    }, [
+        files,
+        deletedFileIds,
+        search?.date,
+        search?.location,
+        activeCollection,
+    ]);
 
     const fileToCollectionsMap = useMemo(() => {
         const fileToCollectionsMap = new Map<number, number[]>();


### PR DESCRIPTION
## Description

The second file Search was causing app to crash.

Fixes it by only updating the files list when data/ location search is done.

## Test Plan

@Jishnuraj9  confirmed his issue is fixed 
