### PR TITLE
Refactor upload types

### DIFF
--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -521,7 +521,7 @@ export const updateCollectionMagicMetadata = async (collection: Collection) => {
 
     const worker = await new CryptoWorker();
 
-    const { file: encryptedMagicMetadata }: EncryptionResult =
+    const { file: encryptedMagicMetadata }: EncryptionResult<string> =
         await worker.encryptMetadata(
             collection.magicMetadata.data,
             collection.key
@@ -532,7 +532,7 @@ export const updateCollectionMagicMetadata = async (collection: Collection) => {
         magicMetadata: {
             version: collection.magicMetadata.version,
             count: collection.magicMetadata.count,
-            data: encryptedMagicMetadata.encryptedData as unknown as string,
+            data: encryptedMagicMetadata.encryptedData,
             header: encryptedMagicMetadata.decryptionHeader,
         },
     };

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -252,14 +252,14 @@ export const updateFileMagicMetadata = async (files: EnteFile[]) => {
     const reqBody: BulkUpdateMagicMetadataRequest = { metadataList: [] };
     const worker = await new CryptoWorker();
     for (const file of files) {
-        const { file: encryptedMagicMetadata }: EncryptionResult =
+        const { file: encryptedMagicMetadata }: EncryptionResult<string> =
             await worker.encryptMetadata(file.magicMetadata.data, file.key);
         reqBody.metadataList.push({
             id: file.id,
             magicMetadata: {
                 version: file.magicMetadata.version,
                 count: file.magicMetadata.count,
-                data: encryptedMagicMetadata.encryptedData as unknown as string,
+                data: encryptedMagicMetadata.encryptedData,
                 header: encryptedMagicMetadata.decryptionHeader,
             },
         });
@@ -286,14 +286,14 @@ export const updateFilePublicMagicMetadata = async (files: EnteFile[]) => {
     const reqBody: BulkUpdateMagicMetadataRequest = { metadataList: [] };
     const worker = await new CryptoWorker();
     for (const file of files) {
-        const { file: encryptedPubMagicMetadata }: EncryptionResult =
+        const { file: encryptedPubMagicMetadata }: EncryptionResult<string> =
             await worker.encryptMetadata(file.pubMagicMetadata.data, file.key);
         reqBody.metadataList.push({
             id: file.id,
             magicMetadata: {
                 version: file.pubMagicMetadata.version,
                 count: file.pubMagicMetadata.count,
-                data: encryptedPubMagicMetadata.encryptedData as unknown as string,
+                data: encryptedPubMagicMetadata.encryptedData,
                 header: encryptedPubMagicMetadata.decryptionHeader,
             },
         });

--- a/src/services/migrateThumbnailService.ts
+++ b/src/services/migrateThumbnailService.ts
@@ -107,19 +107,19 @@ export async function uploadThumbnail(
     updatedThumbnail: Uint8Array,
     uploadURL: UploadURL
 ): Promise<fileAttribute> {
-    const { file: encryptedThumbnail }: EncryptionResult =
+    const { file: encryptedThumbnail }: EncryptionResult<Uint8Array> =
         await worker.encryptThumbnail(updatedThumbnail, fileKey);
     let thumbnailObjectKey: string = null;
     if (USE_CF_PROXY) {
         thumbnailObjectKey = await uploadHttpClient.putFileV2(
             uploadURL,
-            encryptedThumbnail.encryptedData as Uint8Array,
+            encryptedThumbnail.encryptedData,
             () => {}
         );
     } else {
         thumbnailObjectKey = await uploadHttpClient.putFile(
             uploadURL,
-            encryptedThumbnail.encryptedData as Uint8Array,
+            encryptedThumbnail.encryptedData,
             () => {}
         );
     }

--- a/src/services/upload/encryptionService.ts
+++ b/src/services/upload/encryptionService.ts
@@ -33,7 +33,7 @@ async function encryptFileStream(worker, fileData: DataStream) {
 export async function encryptFiledata(
     worker,
     filedata: Uint8Array | DataStream
-): Promise<EncryptionResult> {
+): Promise<EncryptionResult<Uint8Array | DataStream>> {
     return isDataStream(filedata)
         ? await encryptFileStream(worker, filedata)
         : await worker.encryptFile(filedata);

--- a/src/services/upload/fileService.ts
+++ b/src/services/upload/fileService.ts
@@ -106,22 +106,23 @@ export async function encryptFile(
             file.filedata
         );
 
-        const { file: encryptedThumbnail }: EncryptionResult =
+        const { file: encryptedThumbnail }: EncryptionResult<Uint8Array> =
             await worker.encryptThumbnail(file.thumbnail, fileKey);
-        const { file: encryptedMetadata }: EncryptionResult =
+        const { file: encryptedMetadata }: EncryptionResult<string> =
             await worker.encryptMetadata(file.metadata, fileKey);
 
         let encryptedPubMagicMetadata: EncryptedMagicMetadataCore;
         if (file.pubMagicMetadata) {
-            const { file: encryptedPubMagicMetadataData }: EncryptionResult =
-                await worker.encryptMetadata(
-                    file.pubMagicMetadata.data,
-                    fileKey
-                );
+            const {
+                file: encryptedPubMagicMetadataData,
+            }: EncryptionResult<string> = await worker.encryptMetadata(
+                file.pubMagicMetadata.data,
+                fileKey
+            );
             encryptedPubMagicMetadata = {
                 version: file.pubMagicMetadata.version,
                 count: file.pubMagicMetadata.count,
-                data: encryptedPubMagicMetadataData.encryptedData as unknown as string,
+                data: encryptedPubMagicMetadataData.encryptedData,
                 header: encryptedPubMagicMetadataData.decryptionHeader,
             };
         }

--- a/src/services/upload/uploadService.ts
+++ b/src/services/upload/uploadService.ts
@@ -175,13 +175,13 @@ class UploadService {
             if (USE_CF_PROXY) {
                 thumbnailObjectKey = await UploadHttpClient.putFileV2(
                     thumbnailUploadURL,
-                    file.thumbnail.encryptedData as Uint8Array,
+                    file.thumbnail.encryptedData,
                     null
                 );
             } else {
                 thumbnailObjectKey = await UploadHttpClient.putFile(
                     thumbnailUploadURL,
-                    file.thumbnail.encryptedData as Uint8Array,
+                    file.thumbnail.encryptedData,
                     null
                 );
             }

--- a/src/types/file/index.ts
+++ b/src/types/file/index.ts
@@ -1,8 +1,8 @@
 import { MagicMetadataCore, VISIBILITY_STATE } from 'types/magicMetadata';
-import { DataStream, Metadata } from 'types/upload';
+import { Metadata } from 'types/upload';
 
 export interface fileAttribute {
-    encryptedData?: DataStream | Uint8Array;
+    encryptedData?: string;
     objectKey?: string;
     decryptionHeader: string;
 }

--- a/src/types/upload/index.ts
+++ b/src/types/upload/index.ts
@@ -1,6 +1,6 @@
 import { FILE_TYPE } from 'constants/file';
 import { Collection } from 'types/collection';
-import { FilePublicMagicMetadata } from 'types/file';
+import { fileAttribute, FilePublicMagicMetadata } from 'types/file';
 import { EncryptedMagicMetadataCore } from 'types/magicMetadata';
 
 export interface DataStream {
@@ -135,7 +135,12 @@ export interface ProcessedFile {
     pubMagicMetadata: EncryptedMagicMetadataCore;
     localID: number;
 }
-export interface BackupedFile extends Omit<ProcessedFile, 'localID'> {}
+export interface BackupedFile {
+    file: fileAttribute;
+    thumbnail: fileAttribute;
+    metadata: fileAttribute;
+    pubMagicMetadata: EncryptedMagicMetadataCore;
+}
 
 export interface UploadFile extends BackupedFile {
     collectionID: number;

--- a/src/types/upload/index.ts
+++ b/src/types/upload/index.ts
@@ -1,6 +1,6 @@
 import { FILE_TYPE } from 'constants/file';
 import { Collection } from 'types/collection';
-import { fileAttribute, FilePublicMagicMetadata } from 'types/file';
+import { FilePublicMagicMetadata } from 'types/file';
 import { EncryptedMagicMetadataCore } from 'types/magicMetadata';
 
 export interface DataStream {
@@ -12,8 +12,15 @@ export function isDataStream(object: any): object is DataStream {
     return 'stream' in object;
 }
 
-export interface EncryptionResult {
-    file: fileAttribute;
+export interface LocalFileAttributes<
+    T extends string | Uint8Array | DataStream
+> {
+    encryptedData: T;
+    decryptionHeader: string;
+}
+
+export interface EncryptionResult<T extends string | Uint8Array | DataStream> {
+    file: LocalFileAttributes<T>;
     key: string;
 }
 
@@ -122,9 +129,9 @@ export interface EncryptedFile {
     fileKey: B64EncryptionResult;
 }
 export interface ProcessedFile {
-    file: fileAttribute;
-    thumbnail: fileAttribute;
-    metadata: fileAttribute;
+    file: LocalFileAttributes<Uint8Array | DataStream>;
+    thumbnail: LocalFileAttributes<Uint8Array>;
+    metadata: LocalFileAttributes<string>;
     pubMagicMetadata: EncryptedMagicMetadataCore;
     localID: number;
 }


### PR DESCRIPTION
## Description

updated `EncryptionResult` to a generic interface allowing three types `Uint8Array` , `DataStream`, `string`

- `Uint8Array` -> is used for thumbnail and small-sized files (< 20MB)
- `DataStream` ->is used for large files (>20MB)
- `string` -> is used for metadata 



## Test Plan

the changes are just for types, so the typescript/next compiler would have thrown any issue 


