### PR TITLE
Fix alignment of entries within the fix-time dialog

### DIFF
--- a/src/components/FixCreationTime/index.tsx
+++ b/src/components/FixCreationTime/index.tsx
@@ -106,7 +106,6 @@ export default function FixCreationTime(props: Props) {
             <div
                 style={{
                     marginBottom: '10px',
-                    padding: '0 5%',
                     display: 'flex',
                     flexDirection: 'column',
                     ...(fixState === FIX_STATE.RUNNING

--- a/src/components/FixCreationTime/options.tsx
+++ b/src/components/FixCreationTime/options.tsx
@@ -23,7 +23,6 @@ const Option = ({
             color: value !== Number(selected) ? '#aaa' : '#fff',
         }}>
         <Form.Check.Input
-            style={{ marginTop: '6px' }}
             id={value.toString()}
             type="radio"
             value={value}


### PR DESCRIPTION
## Description

Before:
<img width="350" alt="Screenshot 2023-01-02 at 10 24 27 AM" src="https://user-images.githubusercontent.com/1161789/210196133-5a04cb65-fd6c-44f5-872a-b9a221b7a6a6.png">


After:
<img width="350" alt="Screenshot 2023-01-02 at 10 24 56 AM" src="https://user-images.githubusercontent.com/1161789/210196154-d3525c81-228e-47c3-a197-6d9d4057a0bc.png">

