### PR TITLE
ignore zero unix time

### DIFF
--- a/src/utils/time/index.ts
+++ b/src/utils/time/index.ts
@@ -36,8 +36,8 @@ export function getUnixTimeInMicroSeconds(dateTime: Date) {
         return null;
     }
     const unixTime = dateTime.getTime() * 1000;
-    //ignoring dateTimeString = "0000:00:00 00:00:00";
-    if (unixTime === Date.UTC(0, 0, 0, 0, 0, 0, 0)) {
+    //ignoring dateTimeString = "0000:00:00 00:00:00"
+    if (unixTime === Date.UTC(0, 0, 0, 0, 0, 0, 0) || unixTime === 0) {
         return null;
     } else {
         return unixTime;


### PR DESCRIPTION
## Description

^ title 

FFmpeg is returning zero as creation time for some files (when it is unable to find `creationTime` )
rejecting Unix time zero to prevent the setting `creationTime` as zero 

## Test Plan

tested locally 


