### PR TITLE
Handle rename for quick link albums

### DIFF
--- a/src/types/magicMetadata/index.ts
+++ b/src/types/magicMetadata/index.ts
@@ -38,7 +38,9 @@ export enum VISIBILITY_STATE {
 }
 
 export enum SUB_TYPE {
+    DEFAULT = 0,
     DEFAULT_HIDDEN = 1,
+    QUICK_LINK_COLLECTION = 2,
 }
 
 export const NEW_FILE_MAGIC_METADATA: MagicMetadataCore = {

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -238,3 +238,6 @@ export const getNonHiddenCollections = (collections: Collection[]) => {
 export const isCollectionHidden = (collection: Collection) =>
     collection.magicMetadata?.data.visibility === VISIBILITY_STATE.HIDDEN ||
     collection.magicMetadata?.data.subType === SUB_TYPE.DEFAULT_HIDDEN;
+
+export const isQuickLinkCollection = (collection: Collection) =>
+    collection.magicMetadata?.data.subType === SUB_TYPE.QUICK_LINK_COLLECTION;


### PR DESCRIPTION
Description:

This change convert a quick link album to a regular album on rename. 

Test Plan
- Verified that renaming quick link is converting it to an album
- Verified that rename for archived quick link is working as expected.
- Verified that rename for regular album is working as expected