### PR TITLE
fix ffmpeg thumnail generation for non english named files

### DIFF
--- a/src/services/wasm/ffmpeg.ts
+++ b/src/services/wasm/ffmpeg.ts
@@ -56,13 +56,15 @@ export class WasmFFmpeg {
         let tempOutputFilePath: string;
         try {
             await this.ready;
-            tempInputFilePath = `${generateTempName(10)}- ${inputFile.name}`;
+            const extension = getFileExtension(inputFile.name);
+            const tempNameSuffix = extension ? `input.${extension}` : 'input';
+            tempInputFilePath = `${generateTempName(10, tempNameSuffix)}`;
             this.ffmpeg.FS(
                 'writeFile',
                 tempInputFilePath,
                 await getUint8ArrayView(inputFile)
             );
-            tempOutputFilePath = `${generateTempName(10)}-${outputFileName}`;
+            tempOutputFilePath = `${generateTempName(10, outputFileName)}`;
 
             cmd = cmd.map((cmdPart) => {
                 if (cmdPart === FFMPEG_PLACEHOLDER) {
@@ -93,5 +95,13 @@ export class WasmFFmpeg {
                 logError(e, 'unlink output file failed');
             }
         }
+    }
+}
+
+function getFileExtension(filename: string) {
+    const lastDotPosition = filename.lastIndexOf('.');
+    if (lastDotPosition === -1) return null;
+    else {
+        return filename.slice(lastDotPosition + 1);
     }
 }

--- a/src/utils/temp/index.ts
+++ b/src/utils/temp/index.ts
@@ -1,14 +1,14 @@
 const CHARACTERS =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
-export function generateTempName(length: number) {
-    let result = '';
+export function generateTempName(length: number, suffix: string) {
+    let tempName = '';
 
     const charactersLength = CHARACTERS.length;
     for (let i = 0; i < length; i++) {
-        result += CHARACTERS.charAt(
+        tempName += CHARACTERS.charAt(
             Math.floor(Math.random() * charactersLength)
         );
     }
-    return result;
+    return `${tempName}-${suffix}`;
 }


### PR DESCRIPTION
## Description

^ title

fixes by using only the extension part to generate a temp file inside wasm FFmpeg

## Test Plan

tested locally with a file for which it was detected by jishnu   
