### PR TITLE
Handle backdrop click event  to  canceling running upload

### DIFF
--- a/src/components/Collections/CollectionSelector/index.tsx
+++ b/src/components/Collections/CollectionSelector/index.tsx
@@ -19,7 +19,7 @@ export interface CollectionSelectorAttributes {
 
 interface Props {
     open: boolean;
-    onClose: (closeBtnClick?: boolean) => void;
+    onClose: () => void;
     attributes: CollectionSelectorAttributes;
     collections: Collection[];
     collectionSummaries: CollectionSummaries;
@@ -62,18 +62,18 @@ function CollectionSelector({
         props.onClose();
     };
 
-    const onCloseButtonClick = () => {
+    const onUserTriggeredClose = () => {
         attributes.onCancel?.();
-        props.onClose(true);
+        props.onClose();
     };
 
     return (
         <AllCollectionDialog
-            onClose={props.onClose}
+            onClose={onUserTriggeredClose}
             open={props.open}
             position="center"
             fullScreen={appContext.isMobile}>
-            <DialogTitleWithCloseButton onClose={onCloseButtonClick}>
+            <DialogTitleWithCloseButton onClose={onUserTriggeredClose}>
                 {attributes.title}
             </DialogTitleWithCloseButton>
             <DialogContent>

--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -142,6 +142,7 @@ export default function Uploader(props: Props) {
     };
     const handleCollectionSelectorCancel = () => {
         uploadRunning.current = false;
+        appContext.resetSharedFiles();
     };
 
     const handleUserNameInputDialogClose = () => {

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -525,13 +525,6 @@ export default function Gallery() {
         }
     };
 
-    const closeCollectionSelector = (closeBtnClick?: boolean) => {
-        if (closeBtnClick === true) {
-            appContext.resetSharedFiles();
-        }
-        setCollectionSelectorView(false);
-    };
-
     const fixTimeHelper = async () => {
         const selectedFiles = getSelectedFiles(selected, files);
         setFixCreationTimeAttributes({ files: selectedFiles });
@@ -553,6 +546,10 @@ export default function Gallery() {
 
     const openUploader = () => {
         setUploadTypeSelectorView(true);
+    };
+
+    const closeCollectionSelector = () => {
+        setCollectionSelectorView(false);
     };
 
     return (


### PR DESCRIPTION
## Description

backdrop click to close the collectionSelectorDialog was not triggering `onCancel` event and hence the `uploadManager` uploadProgress state was not reset and, new upload got blocked because of that

Fix the issue by calling userTriggeredClose callback for both types of close event 

## Test Plan


tested locally 