### PR TITLE
Change leave shared album option icon

### DIFF
--- a/src/components/Collections/CollectionOptions/SharedCollectionOption.tsx
+++ b/src/components/Collections/CollectionOptions/SharedCollectionOption.tsx
@@ -1,7 +1,6 @@
 import { OverflowMenuOption } from 'components/OverflowMenu/option';
 import React from 'react';
-
-import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
+import LogoutIcon from '@mui/icons-material/Logout';
 import constants from 'utils/strings/constants';
 import { CollectionActions } from '.';
 
@@ -15,7 +14,7 @@ interface Iprops {
 export function SharedCollectionOption({ handleCollectionAction }: Iprops) {
     return (
         <OverflowMenuOption
-            startIcon={<DeleteOutlinedIcon />}
+            startIcon={<LogoutIcon />}
             onClick={handleCollectionAction(
                 CollectionActions.CONFIRM_LEAVE_SHARED_ALBUM,
                 false


### PR DESCRIPTION
## Description
git push --set-upstream origin change-leave-shared-album-option-icon
## Test Plan
![Screenshot from 2023-01-12 10-55-34](https://user-images.githubusercontent.com/55018937/211984596-6717a61b-6c02-48f3-bcae-2263dde8c6d9.png)
