### PR TITLE
remove next-transpile-modules package

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,12 +5,6 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const { withSentryConfig } = require('@sentry/nextjs');
 const { PHASE_DEVELOPMENT_SERVER } = require('next/constants');
 
-const withTM = require('next-transpile-modules')([
-    '@mui/material',
-    '@mui/system',
-    '@mui/icons-material',
-]);
-
 const {
     getGitSha,
     convertToNextHeaderFormat,
@@ -28,40 +22,43 @@ const IS_SENTRY_ENABLED = getIsSentryEnabled();
 
 module.exports = (phase) =>
     withSentryConfig(
-        withBundleAnalyzer(
-            withTM({
-                compiler: {
-                    styledComponents: {
-                        ssr: true,
-                        displayName: true,
-                    },
+        withBundleAnalyzer({
+            transpilePackages: [
+                '@mui/material',
+                '@mui/system',
+                '@mui/icons-material',
+            ],
+            compiler: {
+                styledComponents: {
+                    ssr: true,
+                    displayName: true,
                 },
-                env: {
-                    SENTRY_RELEASE: GIT_SHA,
-                },
+            },
+            env: {
+                SENTRY_RELEASE: GIT_SHA,
+            },
 
-                headers() {
-                    return [
-                        {
-                            // Apply these headers to all routes in your application....
-                            source: ALL_ROUTES,
-                            headers: convertToNextHeaderFormat({
-                                ...COOP_COEP_HEADERS,
-                                ...WEB_SECURITY_HEADERS,
-                                ...buildCSPHeader(CSP_DIRECTIVES),
-                            }),
-                        },
-                    ];
-                },
-                // https://dev.to/marcinwosinek/how-to-add-resolve-fallback-to-webpack-5-in-nextjs-10-i6j
-                webpack: (config, { isServer }) => {
-                    if (!isServer) {
-                        config.resolve.fallback.fs = false;
-                    }
-                    return config;
-                },
-            })
-        ),
+            headers() {
+                return [
+                    {
+                        // Apply these headers to all routes in your application....
+                        source: ALL_ROUTES,
+                        headers: convertToNextHeaderFormat({
+                            ...COOP_COEP_HEADERS,
+                            ...WEB_SECURITY_HEADERS,
+                            ...buildCSPHeader(CSP_DIRECTIVES),
+                        }),
+                    },
+                ];
+            },
+            // https://dev.to/marcinwosinek/how-to-add-resolve-fallback-to-webpack-5-in-nextjs-10-i6j
+            webpack: (config, { isServer }) => {
+                if (!isServer) {
+                    config.resolve.fallback.fs = false;
+                }
+                return config;
+            },
+        }),
         {
             release: GIT_SHA,
             dryRun: phase === PHASE_DEVELOPMENT_SERVER || !IS_SENTRY_ENABLED,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "libsodium-wrappers": "^0.7.8",
     "localforage": "^1.9.0",
     "next": "^13.0.6",
-    "next-transpile-modules": "^10.0.0",
     "photoswipe": "file:./thirdparty/photoswipe",
     "piexifjs": "^1.0.6",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3196,13 +3196,6 @@ negotiator@0.6.2:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-next-transpile-modules@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-10.0.0.tgz#7152880048835acb64d05fc7aa34910cbe7994da"
-  integrity sha512-FyeJ++Lm2Fq31gbThiRCrJlYpIY9QaI7A3TjuhQLzOix8ChQrvn5ny4MhfIthS5cy6+uK1AhDRvxVdW17y3Xdw==
-  dependencies:
-    enhanced-resolve "^5.10.0"
-
 next@^13.0.6:
   version "13.0.6"
   resolved "https://registry.yarnpkg.com/next/-/next-13.0.6.tgz#f9a2e9e2df9ad60e1b6b716488c9ad501a383621"


### PR DESCRIPTION
## Description

fix warning
 > next-transpile-modules@10.0.0: All features of next-transpile-modules are now natively built-in Next.js 13.1. Please use Next's transpilePackages option :)

## Test Plan

tested build and ran locally 