### PR TITLE
Album icon change

### DIFF
--- a/src/components/Collections/CollectionListBar/CollectionCard.tsx
+++ b/src/components/Collections/CollectionListBar/CollectionCard.tsx
@@ -51,7 +51,7 @@ function CollectionCardIcon({ collectionType }) {
         <CollectionBarTileIcon>
             {collectionType === CollectionSummaryType.favorites && <Favorite />}
             {collectionType === CollectionSummaryType.archived && (
-                <ArchiveOutlined />
+                <ArchiveOutlined color="secondary" />
             )}
             {collectionType === CollectionSummaryType.shared && <PeopleIcon />}
         </CollectionBarTileIcon>

--- a/src/components/Collections/CollectionListBar/CollectionCard.tsx
+++ b/src/components/Collections/CollectionListBar/CollectionCard.tsx
@@ -55,7 +55,7 @@ function CollectionCardIcon({ collectionType }) {
                 <ArchiveOutlined color="secondary" />
             )}
             {collectionType === CollectionSummaryType.shared && <PeopleIcon />}
-            {collectionType === CollectionSummaryType.sharedViaLink && (
+            {collectionType === CollectionSummaryType.sharedOnlyViaLink && (
                 <LinkIcon />
             )}
         </CollectionBarTileIcon>

--- a/src/components/Collections/CollectionListBar/CollectionCard.tsx
+++ b/src/components/Collections/CollectionListBar/CollectionCard.tsx
@@ -13,6 +13,7 @@ import { CollectionSummaryType } from 'constants/collection';
 import Favorite from '@mui/icons-material/FavoriteRounded';
 import ArchiveOutlined from '@mui/icons-material/ArchiveOutlined';
 import PeopleIcon from '@mui/icons-material/People';
+import LinkIcon from '@mui/icons-material/Link';
 
 interface Iprops {
     active: boolean;
@@ -54,6 +55,9 @@ function CollectionCardIcon({ collectionType }) {
                 <ArchiveOutlined color="secondary" />
             )}
             {collectionType === CollectionSummaryType.shared && <PeopleIcon />}
+            {collectionType === CollectionSummaryType.sharedViaLink && (
+                <LinkIcon />
+            )}
         </CollectionBarTileIcon>
     );
 }

--- a/src/components/Collections/CollectionListBar/CollectionCard.tsx
+++ b/src/components/Collections/CollectionListBar/CollectionCard.tsx
@@ -11,7 +11,7 @@ import TruncateText from 'components/TruncateText';
 import { Box } from '@mui/material';
 import { CollectionSummaryType } from 'constants/collection';
 import Favorite from '@mui/icons-material/FavoriteRounded';
-import ArchiveOutlined from '@mui/icons-material/ArchiveOutlined';
+import ArchiveIcon from '@mui/icons-material/Archive';
 import PeopleIcon from '@mui/icons-material/People';
 import LinkIcon from '@mui/icons-material/Link';
 
@@ -52,7 +52,7 @@ function CollectionCardIcon({ collectionType }) {
         <CollectionBarTileIcon>
             {collectionType === CollectionSummaryType.favorites && <Favorite />}
             {collectionType === CollectionSummaryType.archived && (
-                <ArchiveOutlined color="secondary" />
+                <ArchiveIcon color="secondary" />
             )}
             {collectionType === CollectionSummaryType.shared && <PeopleIcon />}
             {collectionType === CollectionSummaryType.sharedOnlyViaLink && (

--- a/src/components/Collections/CollectionListBar/CollectionCard.tsx
+++ b/src/components/Collections/CollectionListBar/CollectionCard.tsx
@@ -52,7 +52,11 @@ function CollectionCardIcon({ collectionType }) {
         <CollectionBarTileIcon>
             {collectionType === CollectionSummaryType.favorites && <Favorite />}
             {collectionType === CollectionSummaryType.archived && (
-                <ArchiveIcon color="secondary" />
+                <ArchiveIcon
+                    sx={(theme) => ({
+                        color: theme.palette.fixed.strokeMutedWhite,
+                    })}
+                />
             )}
             {collectionType === CollectionSummaryType.shared && <PeopleIcon />}
             {collectionType === CollectionSummaryType.sharedOnlyViaLink && (

--- a/src/components/Collections/styledComponents.ts
+++ b/src/components/Collections/styledComponents.ts
@@ -78,6 +78,7 @@ export const CollectionBarTileText = styled(Overlay)`
 export const CollectionBarTileIcon = styled(Overlay)`
     padding: 4px;
     display: flex;
+    flex-direction: row-reverse;
     justify-content: flex-end;
     align-items: flex-end;
     & > .MuiSvgIcon-root {

--- a/src/components/Collections/styledComponents.ts
+++ b/src/components/Collections/styledComponents.ts
@@ -78,8 +78,7 @@ export const CollectionBarTileText = styled(Overlay)`
 export const CollectionBarTileIcon = styled(Overlay)`
     padding: 4px;
     display: flex;
-    flex-direction: row-reverse;
-    justify-content: flex-end;
+    justify-content: flex-start;
     align-items: flex-end;
     & > .MuiSvgIcon-root {
         font-size: 20px;

--- a/src/constants/collection/index.ts
+++ b/src/constants/collection/index.ts
@@ -16,6 +16,7 @@ export enum CollectionSummaryType {
     trash = 'trash',
     all = 'all',
     shared = 'shared',
+    sharedViaLink = 'sharedViaLink',
     archived = 'archived',
 }
 export enum COLLECTION_SORT_BY {
@@ -34,6 +35,7 @@ export const COLLECTION_SORT_ORDER = new Map([
     [CollectionSummaryType.album, 2],
     [CollectionSummaryType.folder, 2],
     [CollectionSummaryType.shared, 2],
+    [CollectionSummaryType.sharedViaLink, 2],
     [CollectionSummaryType.archived, 2],
     [CollectionSummaryType.archive, 3],
     [CollectionSummaryType.trash, 4],
@@ -49,6 +51,7 @@ export const UPLOAD_NOT_ALLOWED_COLLECTION_TYPES = new Set([
     CollectionSummaryType.all,
     CollectionSummaryType.archive,
     CollectionSummaryType.shared,
+    CollectionSummaryType.sharedViaLink,
     CollectionSummaryType.trash,
 ]);
 

--- a/src/constants/collection/index.ts
+++ b/src/constants/collection/index.ts
@@ -16,7 +16,7 @@ export enum CollectionSummaryType {
     trash = 'trash',
     all = 'all',
     shared = 'shared',
-    sharedViaLink = 'sharedViaLink',
+    sharedOnlyViaLink = 'sharedOnlyViaLink',
     archived = 'archived',
 }
 export enum COLLECTION_SORT_BY {
@@ -35,7 +35,7 @@ export const COLLECTION_SORT_ORDER = new Map([
     [CollectionSummaryType.album, 2],
     [CollectionSummaryType.folder, 2],
     [CollectionSummaryType.shared, 2],
-    [CollectionSummaryType.sharedViaLink, 2],
+    [CollectionSummaryType.sharedOnlyViaLink, 2],
     [CollectionSummaryType.archived, 2],
     [CollectionSummaryType.archive, 3],
     [CollectionSummaryType.trash, 4],
@@ -51,7 +51,7 @@ export const UPLOAD_NOT_ALLOWED_COLLECTION_TYPES = new Set([
     CollectionSummaryType.all,
     CollectionSummaryType.archive,
     CollectionSummaryType.shared,
-    CollectionSummaryType.sharedViaLink,
+    CollectionSummaryType.sharedOnlyViaLink,
     CollectionSummaryType.trash,
 ]);
 

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -50,6 +50,8 @@ import { User } from 'types/user';
 import {
     getNonHiddenCollections,
     isQuickLinkCollection,
+    isSharedByMe,
+    isSharedWithMe,
 } from 'utils/collection';
 import ComlinkCryptoWorker from 'utils/comlink/ComlinkCryptoWorker';
 
@@ -825,7 +827,7 @@ export function getCollectionSummaries(
                 fileCount: collectionFilesCount.get(collection.id),
                 updationTime: collection.updationTime,
                 type:
-                    collection.owner.id !== user.id
+                    isSharedWithMe(collection, user) || isSharedByMe(collection)
                         ? CollectionSummaryType.shared
                         : IsArchived(collection)
                         ? CollectionSummaryType.archived

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -52,7 +52,7 @@ import {
     isQuickLinkCollection,
     isSharedByMe,
     isSharedWithMe,
-    isSharedViaLink,
+    isSharedOnlyViaLink,
 } from 'utils/collection';
 import ComlinkCryptoWorker from 'utils/comlink/ComlinkCryptoWorker';
 
@@ -830,8 +830,8 @@ export function getCollectionSummaries(
                 type:
                     isSharedWithMe(collection, user) || isSharedByMe(collection)
                         ? CollectionSummaryType.shared
-                        : isSharedViaLink(collection)
-                        ? CollectionSummaryType.sharedViaLink
+                        : isSharedOnlyViaLink(collection)
+                        ? CollectionSummaryType.sharedOnlyViaLink
                         : IsArchived(collection)
                         ? CollectionSummaryType.archived
                         : CollectionSummaryType[collection.type],

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -52,6 +52,7 @@ import {
     isQuickLinkCollection,
     isSharedByMe,
     isSharedWithMe,
+    isSharedViaLink,
 } from 'utils/collection';
 import ComlinkCryptoWorker from 'utils/comlink/ComlinkCryptoWorker';
 
@@ -829,6 +830,8 @@ export function getCollectionSummaries(
                 type:
                     isSharedWithMe(collection, user) || isSharedByMe(collection)
                         ? CollectionSummaryType.shared
+                        : isSharedViaLink(collection)
+                        ? CollectionSummaryType.sharedViaLink
                         : IsArchived(collection)
                         ? CollectionSummaryType.archived
                         : CollectionSummaryType[collection.type],

--- a/src/themes/darkThemeOptions.tsx
+++ b/src/themes/darkThemeOptions.tsx
@@ -230,7 +230,7 @@ const darkThemeOptions = createTheme({
                             };
                         case 'secondary':
                             return {
-                                color: 'rgba(255, 255, 255, 0.48);',
+                                color: 'rgba(255,255,255,0.24)',
                             };
                         case 'disabled':
                             return {

--- a/src/themes/darkThemeOptions.tsx
+++ b/src/themes/darkThemeOptions.tsx
@@ -230,7 +230,7 @@ const darkThemeOptions = createTheme({
                             };
                         case 'secondary':
                             return {
-                                color: 'rgba(255,255,255,0.24)',
+                                color: 'rgba(255, 255, 255, 0.48);',
                             };
                         case 'disabled':
                             return {

--- a/src/themes/darkThemeOptions.tsx
+++ b/src/themes/darkThemeOptions.tsx
@@ -20,6 +20,13 @@ declare module '@mui/material/styles' {
         muted?: string;
         faint?: string;
     }
+
+    interface FixedColor {
+        white: string;
+        black: string;
+        strokeMutedWhite: string;
+    }
+
     interface Palette {
         accent: PaletteColor;
         fill: PaletteColor;
@@ -27,6 +34,7 @@ declare module '@mui/material/styles' {
         blur: BlurStrength;
         danger: PaletteColor;
         stroke: TypeText;
+        fixed: FixedColor;
     }
     interface PaletteOptions {
         accent?: PaletteColorOptions;
@@ -35,6 +43,7 @@ declare module '@mui/material/styles' {
         backdrop?: PaletteColorOptions;
         blur?: BlurStrengthOptions;
         stroke?: Partial<TypeText>;
+        fixed?: Partial<FixedColor>;
     }
 
     interface TypographyVariants {
@@ -300,6 +309,11 @@ const darkThemeOptions = createTheme({
             base: '96px',
             muted: '48px',
             faint: '24px',
+        },
+        fixed: {
+            white: '#fff',
+            black: '#000',
+            strokeMutedWhite: 'rgba(255, 255, 255, 0.48)',
         },
         text: {
             primary: '#fff',

--- a/src/themes/lightThemeOptions.tsx
+++ b/src/themes/lightThemeOptions.tsx
@@ -230,7 +230,7 @@ const lightThemeOptions = createTheme({
                             };
                         case 'secondary':
                             return {
-                                color: 'rgba(0,0,0,0.24)',
+                                color: 'rgba(0,0,0,0.48)',
                             };
                         case 'disabled':
                             return {

--- a/src/themes/lightThemeOptions.tsx
+++ b/src/themes/lightThemeOptions.tsx
@@ -20,6 +20,12 @@ declare module '@mui/material/styles' {
         muted?: string;
         faint?: string;
     }
+
+    interface FixedColor {
+        white: string;
+        black: string;
+        strokeMutedWhite: string;
+    }
     interface Palette {
         accent: PaletteColor;
         fill: PaletteColor;
@@ -27,6 +33,7 @@ declare module '@mui/material/styles' {
         blur: BlurStrength;
         danger: PaletteColor;
         stroke: TypeText;
+        fixed: FixedColor;
     }
     interface PaletteOptions {
         accent?: PaletteColorOptions;
@@ -35,6 +42,7 @@ declare module '@mui/material/styles' {
         backdrop?: PaletteColorOptions;
         blur?: BlurStrengthOptions;
         stroke?: Partial<TypeText>;
+        fixed?: Partial<FixedColor>;
     }
 
     interface TypographyVariants {
@@ -300,6 +308,11 @@ const lightThemeOptions = createTheme({
             base: '96px',
             muted: '48px',
             faint: '24px',
+        },
+        fixed: {
+            white: '#fff',
+            black: '#000',
+            strokeMutedWhite: 'rgba(255, 255, 255, 0.48)',
         },
         text: {
             primary: '#000',

--- a/src/themes/lightThemeOptions.tsx
+++ b/src/themes/lightThemeOptions.tsx
@@ -230,7 +230,7 @@ const lightThemeOptions = createTheme({
                             };
                         case 'secondary':
                             return {
-                                color: 'rgba(0,0,0,0.48)',
+                                color: 'rgba(0,0,0,0.24)',
                             };
                         case 'disabled':
                             return {

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -241,3 +241,10 @@ export const isCollectionHidden = (collection: Collection) =>
 
 export const isQuickLinkCollection = (collection: Collection) =>
     collection.magicMetadata?.data.subType === SUB_TYPE.QUICK_LINK_COLLECTION;
+
+export function isSharedByMe(collection: Collection): boolean {
+    return collection.sharees?.length > 0;
+}
+export function isSharedWithMe(collection: Collection, user: User) {
+    return collection.owner.id !== user.id;
+}

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -248,3 +248,6 @@ export function isSharedByMe(collection: Collection): boolean {
 export function isSharedWithMe(collection: Collection, user: User) {
     return collection.owner.id !== user.id;
 }
+export function isSharedViaLink(collection: Collection) {
+    return collection.publicURLs?.length;
+}

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -248,6 +248,6 @@ export function isSharedByMe(collection: Collection): boolean {
 export function isSharedWithMe(collection: Collection, user: User) {
     return collection.owner.id !== user.id;
 }
-export function isSharedViaLink(collection: Collection) {
-    return collection.publicURLs?.length;
+export function isSharedOnlyViaLink(collection: Collection) {
+    return collection.publicURLs?.length && !collection.sharees?.length;
 }


### PR DESCRIPTION
## Description

1. Changed archived Album icon color to fixed.strokeMutedWhite
2. moved album icon to left bottom
3. show share (people icon) for self shared albums
4. show link icon for albums with just public link

## Test Plan

![Screenshot from 2023-01-18 13-19-20](https://user-images.githubusercontent.com/55018937/213113779-2cdfa601-5ba3-4094-b2bc-f990b1c70566.png)

Share Icon is for only those albums not been shared by anyone via email. Once you share any link shared albums via email, the link icon will disappear and people icon would be shown instead.

