### PR TITLE
fix video playback on safari

### DIFF
--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -320,7 +320,10 @@ export async function getRenderableFileURL(file: EnteFile, fileBlob: Blob) {
             };
         }
         default: {
-            const previewURL = URL.createObjectURL(fileBlob);
+            const previewURL = await createTypedObjectURL(
+                fileBlob,
+                file.metadata.title
+            );
             return {
                 converted: [previewURL],
                 original: [previewURL],


### PR DESCRIPTION
## Description

create typed object URL for safari else it doesn't understand that the file is video

## Test Plan

tested locally
