### PR TITLE
fix gap div between dates missing

### DIFF
--- a/src/components/PhotoList.tsx
+++ b/src/components/PhotoList.tsx
@@ -563,11 +563,14 @@ export function PhotoList({
         switch (listItem.itemType) {
             case ITEM_TYPE.TIME:
                 return listItem.dates ? (
-                    listItem.dates.map((item) => (
-                        <DateContainer key={item.date} span={item.span}>
-                            {item.date}
-                        </DateContainer>
-                    ))
+                    listItem.dates
+                        .map((item) => [
+                            <DateContainer key={item.date} span={item.span}>
+                                {item.date}
+                            </DateContainer>,
+                            <div key={`${item.date}-gap`} />,
+                        ])
+                        .flat()
                 ) : (
                     <DateContainer span={columns}>
                         {listItem.date}


### PR DESCRIPTION
## Description

fixed the date positioning, so that it occupies the space after the gap grid item 

before 
<img width="603" alt="image" src="https://user-images.githubusercontent.com/46242073/213406194-32f33f3b-2ba3-4cea-87e5-d1688a1d1b9b.png">

after
<img width="632" alt="image" src="https://user-images.githubusercontent.com/46242073/213406097-1a00572a-d1af-4b49-828a-23b6bc759f3f.png">


## Test Plan

tested locally 
