### PR TITLE
Album header change

### DIFF
--- a/src/components/Collections/CollectionOptions/FavoritiesCollectionOption.tsx
+++ b/src/components/Collections/CollectionOptions/FavoritiesCollectionOption.tsx
@@ -1,0 +1,26 @@
+import { OverflowMenuOption } from 'components/OverflowMenu/option';
+import React from 'react';
+
+import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import constants from 'utils/strings/constants';
+import { CollectionActions } from '.';
+
+interface Iprops {
+    handleCollectionAction: (
+        action: CollectionActions,
+        loader?: boolean
+    ) => (...args: any[]) => Promise<void>;
+}
+
+export function FavoritiesCollectionOption({ handleCollectionAction }: Iprops) {
+    return (
+        <OverflowMenuOption
+            startIcon={<FileDownloadOutlinedIcon />}
+            onClick={handleCollectionAction(
+                CollectionActions.CONFIRM_DOWNLOAD,
+                false
+            )}>
+            {constants.DOWNLOAD_COLLECTION}
+        </OverflowMenuOption>
+    );
+}

--- a/src/components/Collections/CollectionOptions/QuickOptions.tsx
+++ b/src/components/Collections/CollectionOptions/QuickOptions.tsx
@@ -24,16 +24,14 @@ export function QuickOptions({
         <FlexWrapper sx={{ gap: '16px' }}>
             {!(
                 collectionSummaryType === CollectionSummaryType.trash ||
-                collectionSummaryType === CollectionSummaryType.favorites
+                collectionSummaryType === CollectionSummaryType.favorites ||
+                collectionSummaryType === CollectionSummaryType.incomingShare
             ) && (
                 <Tooltip
                     title={
                         collectionSummaryType ===
                         CollectionSummaryType.outgoingShare
                             ? constants.MODIFY_SHARING
-                            : collectionSummaryType ===
-                              CollectionSummaryType.incomingShare
-                            ? constants.SHARING_DETAILS
                             : constants.SHARE_COLLECTION
                     }>
                     <IconButton>

--- a/src/components/Collections/CollectionOptions/QuickOptions.tsx
+++ b/src/components/Collections/CollectionOptions/QuickOptions.tsx
@@ -70,7 +70,7 @@ export function QuickOptions({
                     <IconButton>
                         <DeleteOutlinedIcon
                             onClick={handleCollectionAction(
-                                CollectionActions.CONFIRM_DELETE,
+                                CollectionActions.CONFIRM_EMPTY_TRASH,
                                 false
                             )}
                         />

--- a/src/components/Collections/CollectionOptions/QuickOptions.tsx
+++ b/src/components/Collections/CollectionOptions/QuickOptions.tsx
@@ -29,6 +29,9 @@ export function QuickOptions({
             ) && (
                 <Tooltip
                     title={
+                        /*: collectionSummaryType ===
+                            CollectionSummaryType.incomingShare
+                          ? constants.SHARING_DETAILS*/
                         collectionSummaryType ===
                         CollectionSummaryType.outgoingShare
                             ? constants.MODIFY_SHARING

--- a/src/components/Collections/CollectionOptions/index.tsx
+++ b/src/components/Collections/CollectionOptions/index.tsx
@@ -18,6 +18,7 @@ import OverflowMenu from 'components/OverflowMenu/menu';
 import { CollectionSummaryType } from 'constants/collection';
 import { TrashCollectionOption } from './TrashCollectionOption';
 import { SharedCollectionOption } from './SharedCollectionOption';
+import { FavoritiesCollectionOption } from './FavoritiesCollectionOption';
 import { QuickOptions } from './QuickOptions';
 import MoreHoriz from '@mui/icons-material/MoreHoriz';
 import { HorizontalFlex } from 'components/Container';
@@ -239,32 +240,36 @@ const CollectionOptions = (props: CollectionOptionsProps) => {
                 handleCollectionAction={handleCollectionAction}
                 collectionSummaryType={collectionSummaryType}
             />
-            {!(collectionSummaryType === CollectionSummaryType.favorites) && (
-                <OverflowMenu
-                    ariaControls={'collection-options'}
-                    triggerButtonIcon={<MoreHoriz />}
-                    triggerButtonProps={{
-                        sx: {
-                            background: (theme) => theme.palette.fill.dark,
-                        },
-                    }}>
-                    {collectionSummaryType === CollectionSummaryType.trash ? (
-                        <TrashCollectionOption
-                            handleCollectionAction={handleCollectionAction}
-                        />
-                    ) : collectionSummaryType ===
-                      CollectionSummaryType.incomingShare ? (
-                        <SharedCollectionOption
-                            handleCollectionAction={handleCollectionAction}
-                        />
-                    ) : (
-                        <AlbumCollectionOption
-                            IsArchived={IsArchived(activeCollection)}
-                            handleCollectionAction={handleCollectionAction}
-                        />
-                    )}
-                </OverflowMenu>
-            )}
+
+            <OverflowMenu
+                ariaControls={'collection-options'}
+                triggerButtonIcon={<MoreHoriz />}
+                triggerButtonProps={{
+                    sx: {
+                        background: (theme) => theme.palette.fill.dark,
+                    },
+                }}>
+                {collectionSummaryType === CollectionSummaryType.trash ? (
+                    <TrashCollectionOption
+                        handleCollectionAction={handleCollectionAction}
+                    />
+                ) : collectionSummaryType ===
+                  CollectionSummaryType.favorites ? (
+                    <FavoritiesCollectionOption
+                        handleCollectionAction={handleCollectionAction}
+                    />
+                ) : collectionSummaryType ===
+                  CollectionSummaryType.incomingShare ? (
+                    <SharedCollectionOption
+                        handleCollectionAction={handleCollectionAction}
+                    />
+                ) : (
+                    <AlbumCollectionOption
+                        IsArchived={IsArchived(activeCollection)}
+                        handleCollectionAction={handleCollectionAction}
+                    />
+                )}
+            </OverflowMenu>
         </HorizontalFlex>
     );
 };

--- a/src/components/OverflowMenu/menu.tsx
+++ b/src/components/OverflowMenu/menu.tsx
@@ -20,6 +20,7 @@ const StyledMenu = styled(Menu)`
     & .MuiList-root {
         padding: 0;
         border: none;
+        width: 220px;
     }
 `;
 

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -50,8 +50,8 @@ import { User } from 'types/user';
 import {
     getNonHiddenCollections,
     isQuickLinkCollection,
-    isSharedByMe,
-    isSharedWithMe,
+    isOutgoingShare,
+    isIncomingShare,
     isSharedOnlyViaLink,
 } from 'utils/collection';
 import ComlinkCryptoWorker from 'utils/comlink/ComlinkCryptoWorker';
@@ -827,9 +827,9 @@ export function getCollectionSummaries(
                 latestFile: collectionLatestFiles.get(collection.id),
                 fileCount: collectionFilesCount.get(collection.id),
                 updationTime: collection.updationTime,
-                type: isSharedWithMe(collection, user)
+                type: isIncomingShare(collection, user)
                     ? CollectionSummaryType.incomingShare
-                    : isSharedByMe(collection)
+                    : isOutgoingShare(collection)
                     ? CollectionSummaryType.outgoingShare
                     : isSharedOnlyViaLink(collection)
                     ? CollectionSummaryType.sharedOnlyViaLink

--- a/src/themes/darkThemeOptions.tsx
+++ b/src/themes/darkThemeOptions.tsx
@@ -232,20 +232,7 @@ const darkThemeOptions = createTheme({
         MuiSvgIcon: {
             styleOverrides: {
                 root: ({ ownerState }) => {
-                    switch (ownerState.color) {
-                        case 'primary':
-                            return {
-                                color: '#ffffff',
-                            };
-                        case 'secondary':
-                            return {
-                                color: 'rgba(255,255,255,0.24)',
-                            };
-                        case 'disabled':
-                            return {
-                                color: 'rgba(255, 255, 255, 0.16)',
-                            };
-                    }
+                    return { ...setColor(ownerState) };
                 },
             },
         },
@@ -253,21 +240,7 @@ const darkThemeOptions = createTheme({
         MuiIconButton: {
             styleOverrides: {
                 root: ({ ownerState }) => {
-                    switch (ownerState.color) {
-                        case 'primary':
-                            return {
-                                color: '#ffffff',
-                            };
-                        case 'secondary':
-                            return {
-                                color: 'rgba(255,255,255,0.24)',
-                            };
-                    }
-                    if (ownerState.disabled) {
-                        return {
-                            color: 'rgba(255, 255, 255, 0.16)',
-                        };
-                    }
+                    return { ...setColor(ownerState), padding: '12px' };
                 },
             },
         },
@@ -403,3 +376,19 @@ const darkThemeOptions = createTheme({
 });
 
 export default darkThemeOptions;
+function setColor(ownerState) {
+    switch (ownerState.color) {
+        case 'primary':
+            return {
+                color: '#ffffff',
+            };
+        case 'secondary':
+            return {
+                color: 'rgba(255,255,255,0.24)',
+            };
+        case 'disabled':
+            return {
+                color: 'rgba(255, 255, 255, 0.16)',
+            };
+    }
+}

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -242,10 +242,10 @@ export const isCollectionHidden = (collection: Collection) =>
 export const isQuickLinkCollection = (collection: Collection) =>
     collection.magicMetadata?.data.subType === SUB_TYPE.QUICK_LINK_COLLECTION;
 
-export function isSharedByMe(collection: Collection): boolean {
+export function isOutgoingShare(collection: Collection): boolean {
     return collection.sharees?.length > 0;
 }
-export function isSharedWithMe(collection: Collection, user: User) {
+export function isIncomingShare(collection: Collection, user: User) {
     return collection.owner.id !== user.id;
 }
 export function isSharedOnlyViaLink(collection: Collection) {


### PR DESCRIPTION
## Description

- [x] [IconButton: Change padding from 8 pixel to 12 pixel](https://github.com/ente-io/photos-web/commit/2822664a5e35ee4a461364e652623e5c853bfb6a)
- [x] [Remove sharing details quick option from incomingShare type albums](https://github.com/ente-io/photos-web/commit/40a590a49103b57ffa050740d5149eaa4b629e60)
- [x] [change overflow menu width to 220px](https://github.com/ente-io/photos-web/pull/891/commits/3f949310614e4878f0bdd8630af879615ff22912)
- [x] change function name from isSharedByMe/isSharedWithMe to isOutgointShare/isIncomingShare 
- [x] [Implement overflow menu for favorites albums](https://github.com/ente-io/photos-web/pull/891/commits/e960967409fc6eed4f438b10771c5dbbf5308460)
## Test Plan
![Screenshot from 2023-01-24 14-07-21](https://user-images.githubusercontent.com/55018937/214245981-c0117415-34b2-446e-a026-d723f7c05b2b.png)
![Screenshot from 2023-01-24 14-07-29](https://user-images.githubusercontent.com/55018937/214245991-38b89faf-e906-49cc-b2c1-37c854db8f92.png)
![Screenshot from 2023-01-24 19-47-18](https://user-images.githubusercontent.com/55018937/214318337-3d8afc34-47b4-4120-9e0f-a3411501ab82.png)

