### PR TITLE
Album header change

### DIFF
--- a/src/components/Collections/CollectionOptions/QuickOptions.tsx
+++ b/src/components/Collections/CollectionOptions/QuickOptions.tsx
@@ -37,13 +37,12 @@ export function QuickOptions({
                             ? constants.MODIFY_SHARING
                             : constants.SHARE_COLLECTION
                     }>
-                    <IconButton>
-                        <PeopleIcon
-                            onClick={handleCollectionAction(
-                                CollectionActions.SHOW_SHARE_DIALOG,
-                                false
-                            )}
-                        />
+                    <IconButton
+                        onClick={handleCollectionAction(
+                            CollectionActions.SHOW_SHARE_DIALOG,
+                            false
+                        )}>
+                        <PeopleIcon />
                     </IconButton>
                 </Tooltip>
             )}
@@ -55,25 +54,23 @@ export function QuickOptions({
                             ? constants.DOWNLOAD_FAVOURITES
                             : constants.DOWNLOAD_COLLECTION
                     }>
-                    <IconButton>
-                        <FileDownloadOutlinedIcon
-                            onClick={handleCollectionAction(
-                                CollectionActions.CONFIRM_DOWNLOAD,
-                                false
-                            )}
-                        />
+                    <IconButton
+                        onClick={handleCollectionAction(
+                            CollectionActions.CONFIRM_DOWNLOAD,
+                            false
+                        )}>
+                        <FileDownloadOutlinedIcon />
                     </IconButton>
                 </Tooltip>
             )}
             {collectionSummaryType === CollectionSummaryType.trash && (
                 <Tooltip title={constants.EMPTY_TRASH}>
-                    <IconButton>
-                        <DeleteOutlinedIcon
-                            onClick={handleCollectionAction(
-                                CollectionActions.CONFIRM_EMPTY_TRASH,
-                                false
-                            )}
-                        />
+                    <IconButton
+                        onClick={handleCollectionAction(
+                            CollectionActions.CONFIRM_EMPTY_TRASH,
+                            false
+                        )}>
+                        <DeleteOutlinedIcon />
                     </IconButton>
                 </Tooltip>
             )}

--- a/src/components/Collections/CollectionOptions/index.tsx
+++ b/src/components/Collections/CollectionOptions/index.tsx
@@ -243,12 +243,7 @@ const CollectionOptions = (props: CollectionOptionsProps) => {
 
             <OverflowMenu
                 ariaControls={'collection-options'}
-                triggerButtonIcon={<MoreHoriz />}
-                triggerButtonProps={{
-                    sx: {
-                        background: (theme) => theme.palette.fill.dark,
-                    },
-                }}>
+                triggerButtonIcon={<MoreHoriz />}>
                 {collectionSummaryType === CollectionSummaryType.trash ? (
                     <TrashCollectionOption
                         handleCollectionAction={handleCollectionAction}

--- a/src/components/OverflowMenu/menu.tsx
+++ b/src/components/OverflowMenu/menu.tsx
@@ -20,7 +20,6 @@ const StyledMenu = styled(Menu)`
     & .MuiList-root {
         padding: 0;
         border: none;
-        width: 220px;
     }
 `;
 

--- a/src/components/OverflowMenu/option.tsx
+++ b/src/components/OverflowMenu/option.tsx
@@ -31,7 +31,7 @@ export function OverflowMenuOption({
         <MenuItem
             onClick={handleClick}
             sx={{
-                width: 180,
+                width: 220,
                 color: (theme) => theme.palette[color].main,
                 padding: 1.5,
                 '& .MuiSvgIcon-root': {


### PR DESCRIPTION
## Description

- [x] [Fix width of overflowMenu options to 220px](https://github.com/ente-io/photos-web/commit/cebfeca1590c7b80dab9d981526646e01e73bc60)
- [x] [move onClick handler from icon to iconbutton](https://github.com/ente-io/photos-web/commit/184f9ab2a6f5b652d9b7a7ebcf5f0345b3708b46)
- [x] [remove background color from options button](https://github.com/ente-io/photos-web/commit/16e73642935fa31fd02b39316ff239467ec3f10f)

## Test Plan
![Screenshot from 2023-01-25 21-29-44](https://user-images.githubusercontent.com/55018937/214612599-9c5e8b47-f20a-45dc-9ef9-5d9181dc2dd4.png)


