### PR TITLE
improve exif error logging

### DIFF
--- a/src/components/PhotoViewer/index.tsx
+++ b/src/components/PhotoViewer/index.tsx
@@ -454,7 +454,9 @@ function PhotoViewer(props: Iprops) {
         } catch (e) {
             setExif({ key: file.src, value: null });
             const fileExtension = getFileExtension(file.metadata.title);
-            logError(e, 'exifr parsing failed', { extension: fileExtension });
+            logError(e, 'checkExifAvailable failed', {
+                extension: fileExtension,
+            });
         }
     };
 

--- a/src/constants/upload/index.ts
+++ b/src/constants/upload/index.ts
@@ -7,13 +7,17 @@ import {
 } from 'types/upload';
 
 // list of format that were missed by type-detection for some files.
-export const FORMAT_MISSED_BY_FILE_TYPE_LIB = [
+export const FILE_TYPE_LIB_MISSED_FORMATS = [
     { fileType: FILE_TYPE.IMAGE, exactType: 'jpeg', mimeType: 'image/jpeg' },
     { fileType: FILE_TYPE.IMAGE, exactType: 'jpg', mimeType: 'image/jpeg' },
     { fileType: FILE_TYPE.VIDEO, exactType: 'webm', mimeType: 'video/webm' },
     { fileType: FILE_TYPE.VIDEO, exactType: 'mod', mimeType: 'video/mpeg' },
     { fileType: FILE_TYPE.VIDEO, exactType: 'mp4', mimeType: 'video/mp4' },
 ];
+
+export const EXIFLESS_FORMATS = ['image/gif'];
+
+export const EXIF_LIBRARY_UNSUPPORTED_FORMATS = ['image/webp'];
 
 // this is the chunk size of the un-encrypted file which is read and encrypted before uploading it as a single part.
 export const MULTIPART_PART_SIZE = 20 * 1024 * 1024;

--- a/src/services/typeDetectionService.ts
+++ b/src/services/typeDetectionService.ts
@@ -1,6 +1,6 @@
 import { FILE_TYPE } from 'constants/file';
 import { ElectronFile, FileTypeInfo } from 'types/upload';
-import { FORMAT_MISSED_BY_FILE_TYPE_LIB } from 'constants/upload';
+import { FILE_TYPE_LIB_MISSED_FORMATS } from 'constants/upload';
 import { CustomError } from 'utils/error';
 import { getFileExtension } from 'utils/file';
 import { logError } from 'utils/sentry';
@@ -46,7 +46,7 @@ export async function getFileType(
         };
     } catch (e) {
         const fileFormat = getFileExtension(receivedFile.name);
-        const formatMissedByTypeDetection = FORMAT_MISSED_BY_FILE_TYPE_LIB.find(
+        const formatMissedByTypeDetection = FILE_TYPE_LIB_MISSED_FORMATS.find(
             (a) => a.exactType === fileFormat
         );
         if (formatMissedByTypeDetection) {

--- a/src/services/upload/exifService.ts
+++ b/src/services/upload/exifService.ts
@@ -1,4 +1,9 @@
-import { NULL_EXTRACTED_METADATA, NULL_LOCATION } from 'constants/upload';
+import {
+    EXIFLESS_FORMATS,
+    EXIF_LIBRARY_UNSUPPORTED_FORMATS,
+    NULL_EXTRACTED_METADATA,
+    NULL_LOCATION,
+} from 'constants/upload';
 import { ElectronFile, Location } from 'types/upload';
 import exifr from 'exifr';
 import piexif from 'piexifjs';
@@ -121,10 +126,19 @@ export async function getRawExif(
     try {
         exifData = await exifr.parse(receivedFile, EXIF_TAGS_NEEDED);
     } catch (e) {
-        logError(e, 'file missing exif data ', {
-            fileType: fileTypeInfo.exactType,
-        });
-        // ignore exif parsing errors
+        if (!EXIFLESS_FORMATS.includes(fileTypeInfo.mimeType)) {
+            if (
+                EXIF_LIBRARY_UNSUPPORTED_FORMATS.includes(fileTypeInfo.mimeType)
+            ) {
+                logError(e, 'exif library unsupported format', {
+                    fileType: fileTypeInfo.exactType,
+                });
+            } else {
+                logError(e, 'get raw exif failed', {
+                    fileType: fileTypeInfo.exactType,
+                });
+            }
+        }
     }
     return exifData;
 }


### PR DESCRIPTION
## Description

- better-named errors 
- avoid logging known format that doesn't have EXIF
- better logs for unsupported formats by the `exifr` llibrary

## Test Plan

tested locally by triggering the getRawExif function for 
- jpeg, 
- webp 
- gif files

- ran the upload dataset exif parsing test


