### PR TITLE
 file not shown on ui after restore

### DIFF
--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -221,7 +221,9 @@ export default function Gallery() {
         useState<SearchResultSummary>(null);
     const syncInProgress = useRef(true);
     const resync = useRef(false);
-    const [deletedFileIds, setDeletedFileIds] = useState(new Set<number>());
+    const [deletedFileIds, setDeletedFileIds] = useState<Set<number>>(
+        new Set<number>()
+    );
     const { startLoading, finishLoading, setDialogMessage, ...appContext } =
         useContext(AppContext);
     const [collectionSummaries, setCollectionSummaries] =

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -221,9 +221,7 @@ export default function Gallery() {
         useState<SearchResultSummary>(null);
     const syncInProgress = useRef(true);
     const resync = useRef(false);
-    const [deletedFileIds, setDeletedFileIds] = useState<Set<number>>(
-        new Set<number>()
-    );
+    const [deletedFileIds, setDeletedFileIds] = useState(new Set<number>());
     const { startLoading, finishLoading, setDialogMessage, ...appContext } =
         useContext(AppContext);
     const [collectionSummaries, setCollectionSummaries] =
@@ -551,6 +549,7 @@ export default function Gallery() {
             });
         } finally {
             await syncWithRemote(false, true);
+            setDeletedFileIds(new Set());
             finishLoading();
         }
     };


### PR DESCRIPTION
## Description

deletedFileIDs was used to hide the deleted files from UI, preemptively so that the files were quickly gone.

But,  Not clearing the deletedFileIDs after completion of the action, caused the file to be not visible on the UI even after the file was restored 

## Test Plan

tested locally 
