### PR TITLE
Fix copy for disable link sharing

### DIFF
--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -690,7 +690,7 @@ const englishConstants = {
     LINK_EXPIRED_MESSAGE: 'This link has either expired or been disabled!',
     MANAGE_LINK: 'Manage link',
     LINK_TOO_MANY_REQUESTS: 'This album is too popular for us to handle!',
-    DISABLE_PUBLIC_SHARING: "'Disable public sharing",
+    DISABLE_PUBLIC_SHARING: 'Disable public sharing',
     DISABLE_PUBLIC_SHARING_MESSAGE:
         'Are you sure you want to disable public sharing?',
     FILE_DOWNLOAD: 'Allow downloads',


### PR DESCRIPTION
## Description

- removed the extra single quote (`'`)

<img width="440" alt="image" src="https://user-images.githubusercontent.com/46242073/215465171-d2174f50-5a0f-4384-8ae7-8fe64bed14a8.png">


## Test Plan

checked locally 
