### PR TITLE
Fix trash sync fail

### DIFF
--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -238,7 +238,8 @@ export const getCollection = async (
         );
         return collectionWithSecrets;
     } catch (e) {
-        logError(e, 'failed to get collection', { collectionID });
+        logError(e, 'failed to get collection');
+        throw e;
     }
 };
 

--- a/src/services/trashService.ts
+++ b/src/services/trashService.ts
@@ -30,7 +30,13 @@ export async function getLocalTrash() {
 export async function getLocalDeletedCollections() {
     const trashedCollections: Array<Collection> =
         (await localForage.getItem<Collection[]>(DELETED_COLLECTION)) || [];
-    return trashedCollections;
+    const nonUndefinedCollections = trashedCollections.filter(
+        (collection) => !!collection
+    );
+    if (nonUndefinedCollections.length !== trashedCollections.length) {
+        await localForage.setItem(DELETED_COLLECTION, nonUndefinedCollections);
+    }
+    return nonUndefinedCollections;
 }
 
 export async function cleanTrashCollections(fileTrash: Trash) {


### PR DESCRIPTION
## Description
- fixed `getCollection` shallowing the error and not rethrowing causing undefined collection to be saved to local DB
- migrated local DB to remove saved undefined deleted-collection entries

## Test Plan

tested locally by reproducing the issue and confirming the fix and the migration works

