### PR TITLE
fix upload to outgoing shared album

### DIFF
--- a/src/constants/collection/index.ts
+++ b/src/constants/collection/index.ts
@@ -53,8 +53,6 @@ export const UPLOAD_NOT_ALLOWED_COLLECTION_TYPES = new Set([
     CollectionSummaryType.all,
     CollectionSummaryType.archive,
     CollectionSummaryType.incomingShare,
-    CollectionSummaryType.outgoingShare,
-    CollectionSummaryType.sharedOnlyViaLink,
     CollectionSummaryType.trash,
 ]);
 


### PR DESCRIPTION
## Description

- UPLOAD_NOT_ALLOWED_COLLECTION_TYPES list had outgoing shared item in the list

## Test Plan

tested locally 
