### PR TITLE
Fix duplicate react key warning 

### DIFF
--- a/src/components/Collections/index.tsx
+++ b/src/components/Collections/index.tsx
@@ -78,12 +78,11 @@ export default function Collections(props: Iprops) {
     );
 
     useEffect(() => {
+        const collectionSummary = collectionSummaries.get(activeCollectionID);
         setPhotoListHeader({
             item: (
                 <CollectionInfoWithOptions
-                    collectionSummary={collectionSummaries.get(
-                        activeCollectionID
-                    )}
+                    collectionSummary={collectionSummary}
                     activeCollection={activeCollection.current}
                     activeCollectionID={activeCollectionID}
                     setCollectionNamerAttributes={setCollectionNamerAttributes}
@@ -94,6 +93,7 @@ export default function Collections(props: Iprops) {
                 />
             ),
             itemType: ITEM_TYPE.HEADER,
+            id: `${activeCollectionID}-${isInSearchMode}-${collectionSummary.fileCount}-${collectionSummary.name}-header}`,
             height: 68,
         });
     }, [collectionSummaries, activeCollectionID, isInSearchMode]);

--- a/src/components/Collections/index.tsx
+++ b/src/components/Collections/index.tsx
@@ -93,7 +93,7 @@ export default function Collections(props: Iprops) {
                 />
             ),
             itemType: ITEM_TYPE.HEADER,
-            id: `${activeCollectionID}-${isInSearchMode}-${collectionSummary.fileCount}-${collectionSummary.name}-header}`,
+            id: `${activeCollectionID}-${isInSearchMode}-${collectionSummary.fileCount}-${collectionSummary.name}-header`,
             height: 68,
         });
     }, [collectionSummaries, activeCollectionID, isInSearchMode]);

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -487,38 +487,32 @@ const PhotoFrame = ({
         }
     };
     const getThumbnail = (
-        files: EnteFile[],
+        file: EnteFile,
         index: number,
         isScrolling: boolean
-    ) =>
-        files[index] ? (
-            <PreviewCard
-                key={`tile-${files[index].id}-selected-${
-                    selected[files[index].id] ?? false
-                }`}
-                file={files[index]}
-                updateURL={updateURL(files[index].id)}
-                onClick={onThumbnailClick(index)}
-                selectable={!isSharedCollection}
-                onSelect={handleSelect(files[index].id, index)}
-                selected={
-                    selected.collectionID === activeCollection &&
-                    selected[files[index].id]
-                }
-                selectOnClick={selected.count > 0}
-                onHover={onHoverOver(index)}
-                onRangeSelect={handleRangeSelect(index)}
-                isRangeSelectActive={isShiftKeyPressed && selected.count > 0}
-                isInsSelectRange={
-                    (index >= rangeStart && index <= currentHover) ||
-                    (index >= currentHover && index <= rangeStart)
-                }
-                activeCollection={activeCollection}
-                showPlaceholder={isScrolling}
-            />
-        ) : (
-            <></>
-        );
+    ) => (
+        <PreviewCard
+            key={`tile-${file.id}-selected-${selected[file.id] ?? false}`}
+            file={file}
+            updateURL={updateURL(file.id)}
+            onClick={onThumbnailClick(index)}
+            selectable={!isSharedCollection}
+            onSelect={handleSelect(file.id, index)}
+            selected={
+                selected.collectionID === activeCollection && selected[file.id]
+            }
+            selectOnClick={selected.count > 0}
+            onHover={onHoverOver(index)}
+            onRangeSelect={handleRangeSelect(index)}
+            isRangeSelectActive={isShiftKeyPressed && selected.count > 0}
+            isInsSelectRange={
+                (index >= rangeStart && index <= currentHover) ||
+                (index >= currentHover && index <= rangeStart)
+            }
+            activeCollection={activeCollection}
+            showPlaceholder={isScrolling}
+        />
+    );
 
     const getSlideData = async (
         instance: any,

--- a/src/components/PhotoList.tsx
+++ b/src/components/PhotoList.tsx
@@ -163,7 +163,7 @@ interface Props {
     filteredData: EnteFile[];
     showAppDownloadBanner: boolean;
     getThumbnail: (
-        files: EnteFile[],
+        file: EnteFile,
         index: number,
         isScrolling?: boolean
     ) => JSX.Element;
@@ -663,7 +663,7 @@ export function PhotoList({
             case ITEM_TYPE.FILE: {
                 const ret = listItem.items.map((item, idx) =>
                     getThumbnail(
-                        filteredData,
+                        item,
                         listItem.itemStartIndex + idx,
                         isScrolling
                     )

--- a/src/components/PhotoList.tsx
+++ b/src/components/PhotoList.tsx
@@ -65,11 +65,11 @@ const getTemplateColumns = (
     groups?: number[]
 ): string => {
     if (groups) {
-        // need to confirm why this was there
-        // const sum = groups.reduce((acc, item) => acc + item, 0);
-        // if (sum < columns) {
-        //     groups[groups.length - 1] += columns - sum;
-        // }
+        // need to confirm why this is there
+        const sum = groups.reduce((acc, item) => acc + item, 0);
+        if (sum < columns) {
+            groups[groups.length - 1] += columns - sum;
+        }
         return groups
             .map(
                 (x) =>
@@ -431,7 +431,7 @@ export function PhotoList({
         );
     };
 
-    const getPhotoListHeader = (photoListHeader) => {
+    const getPhotoListHeader = (photoListHeader: TimeStampListItem) => {
         return {
             ...photoListHeader,
             item: (
@@ -442,7 +442,7 @@ export function PhotoList({
         };
     };
 
-    const getPhotoListFooter = (photoListFooter) => {
+    const getPhotoListFooter = (photoListFooter: TimeStampListItem) => {
         return {
             ...photoListFooter,
             item: (
@@ -453,7 +453,7 @@ export function PhotoList({
         };
     };
 
-    const getEmptyListItem = () => {
+    const getEmptyListItem = (): TimeStampListItem => {
         return {
             itemType: ITEM_TYPE.OTHER,
             item: (
@@ -465,7 +465,9 @@ export function PhotoList({
             height: height - 48,
         };
     };
-    const getVacuumItem = (timeStampList) => {
+    const getVacuumItem = (
+        timeStampList: TimeStampListItem[]
+    ): TimeStampListItem => {
         const footerHeight =
             publicCollectionGalleryContext.accessedThroughSharedURL
                 ? ALBUM_FOOTER_HEIGHT +
@@ -486,10 +488,11 @@ export function PhotoList({
             itemType: ITEM_TYPE.OTHER,
             item: <></>,
             height: Math.max(height - photoFrameHeight - footerHeight, 0),
+            id: 'vacuum',
         };
     };
 
-    const getAppDownloadFooter = () => {
+    const getAppDownloadFooter = (): TimeStampListItem => {
         return {
             itemType: ITEM_TYPE.MARKETING_FOOTER,
             height: FOOTER_HEIGHT,
@@ -500,6 +503,7 @@ export function PhotoList({
                     </Typography>
                 </FooterContainer>
             ),
+            id: 'app-download-footer',
         };
     };
 

--- a/src/components/PhotoList.tsx
+++ b/src/components/PhotoList.tsx
@@ -65,11 +65,6 @@ const getTemplateColumns = (
     groups?: number[]
 ): string => {
     if (groups) {
-        // need to confirm why this is there
-        const sum = groups.reduce((acc, item) => acc + item, 0);
-        if (sum < columns) {
-            groups[groups.length - 1] += columns - sum;
-        }
         return groups
             .map(
                 (x) =>

--- a/src/components/PhotoList.tsx
+++ b/src/components/PhotoList.tsx
@@ -484,11 +484,15 @@ export function PhotoList({
             }
             return sum;
         })();
+        const itemHeight = Math.max(
+            height - photoFrameHeight - footerHeight,
+            0
+        );
         return {
             itemType: ITEM_TYPE.OTHER,
             item: <></>,
-            height: Math.max(height - photoFrameHeight - footerHeight, 0),
-            id: 'vacuum',
+            height: itemHeight,
+            id: `vacuum-${itemHeight}`,
         };
     };
 
@@ -622,11 +626,9 @@ export function PhotoList({
     const generateKey = (index) => {
         switch (timeStampList[index].itemType) {
             case ITEM_TYPE.FILE:
-                return `${timeStampList[index].items[0].id}-${
-                    timeStampList[index].items.slice(-1)[0].id
-                }`;
+                return `${timeStampList[index].items[0].id}-${timeStampList[index].items.length}`;
             default:
-                return `${timeStampList[index].id}-${index}`;
+                return `${timeStampList[index].id}`;
         }
     };
 
@@ -670,7 +672,11 @@ export function PhotoList({
                     let sum = 0;
                     for (let i = 0; i < listItem.groups.length - 1; i++) {
                         sum = sum + listItem.groups[i];
-                        ret.splice(sum, 0, <div />);
+                        ret.splice(
+                            sum,
+                            0,
+                            <div key={`${listItem.items[0].id}-${i}-gap`} />
+                        );
                         sum += 1;
                     }
                 }

--- a/src/components/pages/gallery/PreviewCard.tsx
+++ b/src/components/pages/gallery/PreviewCard.tsx
@@ -294,7 +294,7 @@ export default function PreviewCard(props: IProps) {
 
     return (
         <Cont
-            id={`thumb-${file?.id}-${props.showPlaceholder}`}
+            key={`thumb-${file?.id}-${props.showPlaceholder}`}
             onClick={handleClick}
             onMouseEnter={handleHover}
             disabled={!file?.msrc && !imgSrc}

--- a/src/pages/shared-albums/index.tsx
+++ b/src/pages/shared-albums/index.tsx
@@ -204,6 +204,7 @@ export default function PublicCollectionGallery() {
                 ),
                 itemType: ITEM_TYPE.HEADER,
                 height: 68,
+                id: `collection-info-${publicCollection.name}-${publicFiles.length}`,
             });
     }, [publicCollection, publicFiles]);
 
@@ -222,6 +223,7 @@ export default function PublicCollectionGallery() {
                     </CenteredFlex>
                 ),
                 itemType: ITEM_TYPE.FOOTER,
+                id: 'upload-button',
                 height: 104,
             });
         } else {


### PR DESCRIPTION
## Description

- added proper keys to the album header and footers and other non file/ date  rows
- updated `getThumbnail` to accept `file` item and index instead of the complete array 

## Test Plan

- [ ] check collection info bar is properly updated on collection change, search
- [ ] preview card working properly, 
       -  check scrolling through the gallery doesn't cause re-render
       - sync doesn't cause renderers
       - range select and normal select works
       - it updates the file properly 
       - in range select and select on click works
- [ ] check vacuum components are rendering properly and changing as per need
- [ ] verified the generate key logic correctness 
