### PR TITLE
Allow incoming album selection

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -504,7 +504,6 @@ const PhotoFrame = ({
                 file={files[index]}
                 updateURL={updateURL(files[index].id)}
                 onClick={onThumbnailClick(index)}
-                selectable={!isIncomingSharedCollection}
                 onSelect={handleSelect(files[index].id, index)}
                 selected={
                     selected.collectionID === activeCollection &&

--- a/src/components/pages/gallery/PreviewCard.tsx
+++ b/src/components/pages/gallery/PreviewCard.tsx
@@ -20,7 +20,6 @@ interface IProps {
     file: EnteFile;
     updateURL: (url: string) => EnteFile;
     onClick: () => void;
-    selectable: boolean;
     selected: boolean;
     onSelect: (checked: boolean) => void;
     onHover: () => void;
@@ -203,7 +202,7 @@ export default function PreviewCard(props: IProps) {
         file,
         onClick,
         updateURL,
-        selectable,
+
         selected,
         onSelect,
         selectOnClick,
@@ -298,16 +297,15 @@ export default function PreviewCard(props: IProps) {
             onClick={handleClick}
             onMouseEnter={handleHover}
             disabled={!file?.msrc && !imgSrc}
-            {...(selectable ? useLongPress(longPressCallback, 500) : {})}>
-            {selectable && (
-                <Check
-                    type="checkbox"
-                    checked={selected}
-                    onChange={handleSelect}
-                    $active={isRangeSelectActive && isInsSelectRange}
-                    onClick={(e) => e.stopPropagation()}
-                />
-            )}
+            {...useLongPress(longPressCallback, 500)}>
+            <Check
+                type="checkbox"
+                checked={selected}
+                onChange={handleSelect}
+                $active={isRangeSelectActive && isInsSelectRange}
+                onClick={(e) => e.stopPropagation()}
+            />
+
             {(file?.msrc || imgSrc) && <img src={file?.msrc || imgSrc} />}
             {file?.metadata.fileType === 1 && <PlayCircleOutlineOutlinedIcon />}
             <SelectedOverlay selected={selected} />

--- a/src/components/pages/gallery/SelectedFileOptions.tsx
+++ b/src/components/pages/gallery/SelectedFileOptions.tsx
@@ -41,6 +41,7 @@ interface Props {
     activeCollection: number;
     isFavoriteCollection: boolean;
     isUncategorizedCollection: boolean;
+    isIncomingSharedCollection: boolean;
 }
 
 const SelectedFileOptions = ({
@@ -60,6 +61,7 @@ const SelectedFileOptions = ({
     activeCollection,
     isFavoriteCollection,
     isUncategorizedCollection,
+    isIncomingSharedCollection,
 }: Props) => {
     const { setDialogMessage } = useContext(AppContext);
     const addToCollection = () =>
@@ -142,6 +144,11 @@ const SelectedFileOptions = ({
                     </>
                 ) : isUncategorizedCollection ? (
                     <>
+                        <Tooltip title={constants.DOWNLOAD}>
+                            <IconButton onClick={downloadHelper}>
+                                <DownloadIcon />
+                            </IconButton>
+                        </Tooltip>
                         <Tooltip title={constants.MOVE}>
                             <IconButton onClick={moveToCollection}>
                                 <MoveIcon />
@@ -153,6 +160,12 @@ const SelectedFileOptions = ({
                             </IconButton>
                         </Tooltip>
                     </>
+                ) : isIncomingSharedCollection ? (
+                    <Tooltip title={constants.DOWNLOAD}>
+                        <IconButton onClick={downloadHelper}>
+                            <DownloadIcon />
+                        </IconButton>
+                    </Tooltip>
                 ) : (
                     <>
                         <Tooltip title={constants.FIX_CREATION_TIME}>

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -785,6 +785,11 @@ export default function Gallery() {
                                     ?.type ===
                                 CollectionSummaryType.uncategorized
                             }
+                            isIncomingSharedCollection={
+                                collectionSummaries.get(activeCollection)
+                                    ?.type ===
+                                CollectionSummaryType.incomingShare
+                            }
                         />
                     )}
             </FullScreenDropZone>


### PR DESCRIPTION
## Description
- re-enabled incoming album file selection
- file selection option has just download

<img width="723" alt="image" src="https://user-images.githubusercontent.com/46242073/216539283-54aace93-237c-4ceb-aada-d1af37929623.png">

also added the missing download option on selection to uncategorized album

<img width="725" alt="image" src="https://user-images.githubusercontent.com/46242073/216539676-07aed0da-4570-4128-82d1-94e9237e5dc0.png">


## Test Plan

tested locally
