### PR TITLE
fix patches of thumbnail not loading 

### DIFF
--- a/src/components/pages/gallery/PreviewCard.tsx
+++ b/src/components/pages/gallery/PreviewCard.tsx
@@ -221,6 +221,12 @@ export default function PreviewCard(props: IProps) {
     const isMounted = useRef(true);
 
     useEffect(() => {
+        return () => {
+            isMounted.current = false;
+        };
+    }, []);
+
+    useEffect(() => {
         if (!file.msrc && !props.showPlaceholder) {
             const main = async () => {
                 try {
@@ -253,9 +259,6 @@ export default function PreviewCard(props: IProps) {
                 }
             };
             main();
-            return () => {
-                isMounted.current = false;
-            };
         }
     }, [props.showPlaceholder]);
 


### PR DESCRIPTION
## Description

The component was marked as unmounted wrongly and hence the URL for the thumb was not updated.

fixes by using a a correct `useEffect` to set isMounted property 

## Test Plan

tested locally