### PR TITLE
refactor family utils

### DIFF
--- a/src/components/MemberSubscriptionManage.tsx
+++ b/src/components/MemberSubscriptionManage.tsx
@@ -3,7 +3,7 @@ import VerticallyCentered, { FlexWrapper } from 'components/Container';
 import { AppContext } from 'pages/_app';
 import React, { useContext, useEffect } from 'react';
 import billingService from 'services/billingService';
-import { getFamilyPlanAdmin } from 'utils/billing';
+import { getFamilyPlanAdmin } from 'utils/user/family';
 import { preloadImage } from 'utils/common';
 import constants from 'utils/strings/constants';
 import DialogTitleWithCloseButton from './DialogBox/TitleWithCloseButton';

--- a/src/components/Sidebar/SubscriptionCard/contentOverlay/family/index.tsx
+++ b/src/components/Sidebar/SubscriptionCard/contentOverlay/family/index.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { UserDetails } from 'types/user';
-import { isPartOfFamily } from 'utils/billing';
+import { isPartOfFamily } from 'utils/user/family';
 import StorageSection from '../storageSection';
 import { FamilyUsageSection } from './usageSection';
 

--- a/src/components/Sidebar/SubscriptionCard/contentOverlay/index.tsx
+++ b/src/components/Sidebar/SubscriptionCard/contentOverlay/index.tsx
@@ -1,7 +1,7 @@
 import { IndividualSubscriptionCardContent } from './individual';
 import { FamilySubscriptionCardContent } from './family';
 import React from 'react';
-import { hasNonAdminFamilyMembers } from 'utils/billing';
+import { hasNonAdminFamilyMembers } from 'utils/user/family';
 import { Overlay, SpaceBetweenFlex } from 'components/Container';
 import { UserDetails } from 'types/user';
 

--- a/src/components/Sidebar/SubscriptionStatus/index.tsx
+++ b/src/components/Sidebar/SubscriptionStatus/index.tsx
@@ -2,9 +2,7 @@ import { GalleryContext } from 'pages/gallery';
 import React, { MouseEventHandler, useContext, useMemo } from 'react';
 import {
     hasPaidSubscription,
-    isFamilyAdmin,
     isOnFreePlan,
-    isPartOfFamily,
     hasExceededStorageQuota,
     isSubscriptionActive,
     isSubscriptionCancelled,
@@ -15,6 +13,7 @@ import { UserDetails } from 'types/user';
 import constants from 'utils/strings/constants';
 import { Typography } from '@mui/material';
 import billingService from 'services/billingService';
+import { isPartOfFamily, isFamilyAdmin } from 'utils/user/family';
 
 export default function SubscriptionStatus({
     userDetails,

--- a/src/components/Sidebar/userDetailsSection.tsx
+++ b/src/components/Sidebar/userDetailsSection.tsx
@@ -9,7 +9,7 @@ import SubscriptionStatus from './SubscriptionStatus';
 import { Box, Skeleton } from '@mui/material';
 import { MemberSubscriptionManage } from '../MemberSubscriptionManage';
 import { GalleryContext } from 'pages/gallery';
-import { isPartOfFamily, isFamilyAdmin } from 'utils/billing';
+import { isFamilyAdmin, isPartOfFamily } from 'utils/user/family';
 
 export default function UserDetailsSection({ sidebarView }) {
     const galleryContext = useContext(GalleryContext);

--- a/src/components/pages/gallery/PlanSelector/card/index.tsx
+++ b/src/components/pages/gallery/PlanSelector/card/index.tsx
@@ -11,8 +11,6 @@ import {
     hasMobileSubscription,
     getLocalUserSubscription,
     hasPaidSubscription,
-    getTotalFamilyUsage,
-    isPartOfFamily,
     isSubscriptionActive,
 } from 'utils/billing';
 import { reverseString } from 'utils/common';
@@ -28,6 +26,7 @@ import { getLocalUserDetails } from 'utils/user';
 import { PLAN_PERIOD } from 'constants/gallery';
 import FreeSubscriptionPlanSelectorCard from './free';
 import PaidSubscriptionPlanSelectorCard from './paid';
+import { isPartOfFamily, getTotalFamilyUsage } from 'utils/user/family';
 
 interface Props {
     closeModal: any;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -18,12 +18,12 @@ import {
     UserDetails,
     DeleteChallengeResponse,
 } from 'types/user';
-import { getLocalFamilyData, isPartOfFamily } from 'utils/billing';
 import { ServerErrorCodes } from 'utils/error';
 import isElectron from 'is-electron';
 import safeStorageService from './electron/safeStorage';
 import { deleteThumbnailCache } from './cacheService';
 import { B64EncryptionResult } from 'types/crypto';
+import { isPartOfFamily, getLocalFamilyData } from 'utils/user/family';
 
 const ENDPOINT = getEndpoint();
 

--- a/src/utils/billing/index.ts
+++ b/src/utils/billing/index.ts
@@ -8,8 +8,9 @@ import { CustomError } from '../error';
 import { logError } from '../sentry';
 import { SetDialogBoxAttributes } from 'types/dialogBox';
 import { getFamilyPortalRedirectURL } from 'services/userService';
-import { FamilyData, FamilyMember, User, UserDetails } from 'types/user';
 import { openLink } from 'utils/common';
+import { isPartOfFamily, getTotalFamilyUsage } from 'utils/user/family';
+import { UserDetails } from 'types/user';
 
 const PAYMENT_PROVIDER_STRIPE = 'stripe';
 const PAYMENT_PROVIDER_APPSTORE = 'appstore';
@@ -97,50 +98,8 @@ export function isSubscriptionCancelled(subscription: Subscription) {
     return subscription && subscription.attributes.isCancelled;
 }
 
-// isPartOfFamily return true if the current user is part of some family plan
-export function isPartOfFamily(familyData: FamilyData): boolean {
-    return Boolean(
-        familyData && familyData.members && familyData.members.length > 0
-    );
-}
-
-// hasNonAdminFamilyMembers return true if the admin user has members in his family
-export function hasNonAdminFamilyMembers(familyData: FamilyData): boolean {
-    return Boolean(isPartOfFamily(familyData) && familyData.members.length > 1);
-}
-
-export function isFamilyAdmin(familyData: FamilyData): boolean {
-    const familyAdmin: FamilyMember = getFamilyPlanAdmin(familyData);
-    const user: User = getData(LS_KEYS.USER);
-    return familyAdmin.email === user.email;
-}
-
-export function getFamilyPlanAdmin(familyData: FamilyData): FamilyMember {
-    if (isPartOfFamily(familyData)) {
-        return familyData.members.find((x) => x.isAdmin);
-    } else {
-        logError(
-            Error(
-                'verify user is part of family plan before calling this method'
-            ),
-            'invalid getFamilyPlanAdmin call'
-        );
-    }
-}
-
-export function getTotalFamilyUsage(familyData: FamilyData): number {
-    return familyData.members.reduce(
-        (sum, currentMember) => sum + currentMember.usage,
-        0
-    );
-}
-
 export function getLocalUserSubscription(): Subscription {
     return getData(LS_KEYS.SUBSCRIPTION);
-}
-
-export function getLocalFamilyData(): FamilyData {
-    return getData(LS_KEYS.FAMILY_DATA);
 }
 
 export function isUserSubscribedPlan(plan: Plan, subscription: Subscription) {

--- a/src/utils/user/family.ts
+++ b/src/utils/user/family.ts
@@ -1,0 +1,45 @@
+import { FamilyData, FamilyMember, User } from 'types/user';
+import { logError } from 'utils/sentry';
+import { getData, LS_KEYS } from 'utils/storage/localStorage';
+
+export function getLocalFamilyData(): FamilyData {
+    return getData(LS_KEYS.FAMILY_DATA);
+}
+
+// isPartOfFamily return true if the current user is part of some family plan
+export function isPartOfFamily(familyData: FamilyData): boolean {
+    return Boolean(
+        familyData && familyData.members && familyData.members.length > 0
+    );
+}
+
+// hasNonAdminFamilyMembers return true if the admin user has members in his family
+export function hasNonAdminFamilyMembers(familyData: FamilyData): boolean {
+    return Boolean(isPartOfFamily(familyData) && familyData.members.length > 1);
+}
+
+export function isFamilyAdmin(familyData: FamilyData): boolean {
+    const familyAdmin: FamilyMember = getFamilyPlanAdmin(familyData);
+    const user: User = getData(LS_KEYS.USER);
+    return familyAdmin.email === user.email;
+}
+
+export function getFamilyPlanAdmin(familyData: FamilyData): FamilyMember {
+    if (isPartOfFamily(familyData)) {
+        return familyData.members.find((x) => x.isAdmin);
+    } else {
+        logError(
+            Error(
+                'verify user is part of family plan before calling this method'
+            ),
+            'invalid getFamilyPlanAdmin call'
+        );
+    }
+}
+
+export function getTotalFamilyUsage(familyData: FamilyData): number {
+    return familyData.members.reduce(
+        (sum, currentMember) => sum + currentMember.usage,
+        0
+    );
+}


### PR DESCRIPTION
## Description
- refactored family utils, into a separate file 

This prevents `window` object from being referenced in a worker. 

The cause of the issue is Mui component using window object, which is import of the  in the `englishConstant` file. And indirectly leads to the window object being referenced in the worker. 

This is just a temporary fix, a better solution would be to separate the englishConstants file into `englishConstants` and `englishComponents`.

But that requires a lot of refactoring so did this for now.

## Test Plan

Only imports have changes, so just tested the build is working properly 


