### PR TITLE
Motion photo service ML updates

### DIFF
--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -32,7 +32,6 @@ import { EnteFile } from 'types/file';
 
 import { decodeMotionPhoto } from './motionPhotoService';
 import {
-    fileNameWithoutExtension,
     generateStreamFromArrayBuffer,
     getFileExtension,
     mergeMetadata,
@@ -466,8 +465,7 @@ class ExportService {
         collectionPath: string
     ) {
         const fileBlob = await new Response(fileStream).blob();
-        const originalName = fileNameWithoutExtension(file.metadata.title);
-        const motionPhoto = await decodeMotionPhoto(fileBlob, originalName);
+        const motionPhoto = await decodeMotionPhoto(file, fileBlob);
         const imageStream = generateStreamFromArrayBuffer(motionPhoto.image);
         const imageSaveName = getUniqueFileSaveName(
             collectionPath,

--- a/src/services/motionPhotoService.ts
+++ b/src/services/motionPhotoService.ts
@@ -1,5 +1,6 @@
 import JSZip from 'jszip';
-import { fileExtensionWithDot } from 'utils/file';
+import { EnteFile } from 'types/file';
+import { fileExtensionWithDot, fileNameWithoutExtension } from 'utils/file';
 
 class MotionPhoto {
     image: Uint8Array;
@@ -8,10 +9,8 @@ class MotionPhoto {
     videoNameTitle: string;
 }
 
-export const decodeMotionPhoto = async (
-    zipBlob: Blob,
-    originalName: string
-) => {
+export const decodeMotionPhoto = async (file: EnteFile, zipBlob: Blob) => {
+    const originalName = fileNameWithoutExtension(file.metadata.title);
     const zip = await JSZip.loadAsync(zipBlob, { createFolders: true });
 
     const motionPhoto = new MotionPhoto();

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -95,8 +95,7 @@ export async function downloadFile(
     let tempURL: string;
 
     if (file.metadata.fileType === FILE_TYPE.LIVE_PHOTO) {
-        const originalName = fileNameWithoutExtension(file.metadata.title);
-        const motionPhoto = await decodeMotionPhoto(fileBlob, originalName);
+        const motionPhoto = await decodeMotionPhoto(file, fileBlob);
         const image = new File([motionPhoto.image], motionPhoto.imageNameTitle);
         const imageType = await getFileType(image);
         tempImageURL = URL.createObjectURL(
@@ -306,8 +305,7 @@ async function getRenderableLivePhoto(
     file: EnteFile,
     fileBlob: Blob
 ): Promise<Blob[]> {
-    const originalName = fileNameWithoutExtension(file.metadata.title);
-    const motionPhoto = await decodeMotionPhoto(fileBlob, originalName);
+    const motionPhoto = await decodeMotionPhoto(file, fileBlob);
     const imageBlob = new Blob([motionPhoto.image]);
     return await Promise.all([
         getRenderableImage(motionPhoto.imageNameTitle, imageBlob),

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -48,70 +48,79 @@ export async function downloadFile(
     token?: string,
     passwordToken?: string
 ) {
-    let fileBlob: Blob;
-    const fileReader = new FileReader();
-    if (accessedThroughSharedURL) {
-        const fileURL =
-            await PublicCollectionDownloadManager.getCachedOriginalFile(
+    try {
+        let fileBlob: Blob;
+        const fileReader = new FileReader();
+        if (accessedThroughSharedURL) {
+            const fileURL =
+                await PublicCollectionDownloadManager.getCachedOriginalFile(
+                    file
+                )[0];
+            if (!fileURL) {
+                fileBlob = await new Response(
+                    await PublicCollectionDownloadManager.downloadFile(
+                        token,
+                        passwordToken,
+                        file
+                    )
+                ).blob();
+            } else {
+                fileBlob = await (await fetch(fileURL)).blob();
+            }
+        } else {
+            const fileURL = await DownloadManager.getCachedOriginalFile(
                 file
             )[0];
-        if (!fileURL) {
-            fileBlob = await new Response(
-                await PublicCollectionDownloadManager.downloadFile(
-                    token,
-                    passwordToken,
-                    file
-                )
-            ).blob();
-        } else {
-            fileBlob = await (await fetch(fileURL)).blob();
+            if (!fileURL) {
+                fileBlob = await new Response(
+                    await DownloadManager.downloadFile(file)
+                ).blob();
+            } else {
+                fileBlob = await (await fetch(fileURL)).blob();
+            }
         }
-    } else {
-        const fileURL = await DownloadManager.getCachedOriginalFile(file)[0];
-        if (!fileURL) {
-            fileBlob = await new Response(
-                await DownloadManager.downloadFile(file)
-            ).blob();
+
+        if (file.metadata.fileType === FILE_TYPE.LIVE_PHOTO) {
+            const motionPhoto = await decodeMotionPhoto(file, fileBlob);
+            const image = new File(
+                [motionPhoto.image],
+                motionPhoto.imageNameTitle
+            );
+            const imageType = await getFileType(image);
+            const tempImageURL = URL.createObjectURL(
+                new Blob([motionPhoto.image], { type: imageType.mimeType })
+            );
+            const video = new File(
+                [motionPhoto.video],
+                motionPhoto.videoNameTitle
+            );
+            const videoType = await getFileType(video);
+            const tempVideoURL = URL.createObjectURL(
+                new Blob([motionPhoto.video], { type: videoType.mimeType })
+            );
+            downloadUsingAnchor(tempImageURL, motionPhoto.imageNameTitle);
+            downloadUsingAnchor(tempVideoURL, motionPhoto.videoNameTitle);
         } else {
-            fileBlob = await (await fetch(fileURL)).blob();
+            const fileType = await getFileType(
+                new File([fileBlob], file.metadata.title)
+            );
+            if (
+                file.pubMagicMetadata?.data.editedTime &&
+                (fileType.exactType === TYPE_JPEG ||
+                    fileType.exactType === TYPE_JPG)
+            ) {
+                fileBlob = await updateFileCreationDateInEXIF(
+                    fileReader,
+                    fileBlob,
+                    new Date(file.pubMagicMetadata.data.editedTime / 1000)
+                );
+            }
+            fileBlob = new Blob([fileBlob], { type: fileType.mimeType });
+            const tempURL = URL.createObjectURL(fileBlob);
+            downloadUsingAnchor(tempURL, file.metadata.title);
         }
-    }
-
-    const fileType = await getFileType(
-        new File([fileBlob], file.metadata.title)
-    );
-    if (
-        file.pubMagicMetadata?.data.editedTime &&
-        (fileType.exactType === TYPE_JPEG || fileType.exactType === TYPE_JPG)
-    ) {
-        fileBlob = await updateFileCreationDateInEXIF(
-            fileReader,
-            fileBlob,
-            new Date(file.pubMagicMetadata.data.editedTime / 1000)
-        );
-    }
-    let tempImageURL: string;
-    let tempVideoURL: string;
-    let tempURL: string;
-
-    if (file.metadata.fileType === FILE_TYPE.LIVE_PHOTO) {
-        const motionPhoto = await decodeMotionPhoto(file, fileBlob);
-        const image = new File([motionPhoto.image], motionPhoto.imageNameTitle);
-        const imageType = await getFileType(image);
-        tempImageURL = URL.createObjectURL(
-            new Blob([motionPhoto.image], { type: imageType.mimeType })
-        );
-        const video = new File([motionPhoto.video], motionPhoto.videoNameTitle);
-        const videoType = await getFileType(video);
-        tempVideoURL = URL.createObjectURL(
-            new Blob([motionPhoto.video], { type: videoType.mimeType })
-        );
-        downloadUsingAnchor(tempImageURL, motionPhoto.imageNameTitle);
-        downloadUsingAnchor(tempVideoURL, motionPhoto.videoNameTitle);
-    } else {
-        fileBlob = new Blob([fileBlob], { type: fileType.mimeType });
-        tempURL = URL.createObjectURL(fileBlob);
-        downloadUsingAnchor(tempURL, file.metadata.title);
+    } catch (e) {
+        logError(e, 'failed to download file');
     }
 }
 


### PR DESCRIPTION
## Description

- move the original name from file title logic to inside of decodeMotionPhoto
- wrapped `downloadFile` util in try-catch block
- moved image exif data updating logic to else block

## Test Plan

- tested playback of a live photo 
- tested download of image, video and live photo


