### PR TITLE
Remove deprecated search API

### DIFF
--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -22,7 +22,6 @@ import { Person, Thing } from 'types/machineLearning';
 import { getUniqueFiles } from 'utils/file';
 import { User } from 'types/user';
 import { getData, LS_KEYS } from 'utils/storage/localStorage';
-import { addLogLine } from 'utils/logging';
 
 const DIGITS = new Set(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
 
@@ -292,7 +291,7 @@ async function searchLocation(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     searchPhrase: string
 ): Promise<LocationSearchResponse[]> {
-    addLogLine(`attempting to use unimplemented search API`);
+    logError(Error(), 'attempting to use unimplemented search API');
     return [];
 }
 

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -1,14 +1,10 @@
 import * as chrono from 'chrono-node';
-import { getEndpoint } from 'utils/common/apiUtil';
-import { getToken } from 'utils/common/key';
-import HTTPService from './HTTPService';
 import { getAllPeople } from 'utils/machineLearning';
 import constants from 'utils/strings/constants';
 import mlIDbStorage from 'utils/storage/mlIDbStorage';
 import { getMLSyncConfig } from 'utils/machineLearning/config';
 import { Collection } from 'types/collection';
 import { EnteFile } from 'types/file';
-
 import { logError } from 'utils/sentry';
 import {
     Bbox,
@@ -26,8 +22,7 @@ import { Person, Thing } from 'types/machineLearning';
 import { getUniqueFiles } from 'utils/file';
 import { User } from 'types/user';
 import { getData, LS_KEYS } from 'utils/storage/localStorage';
-
-const ENDPOINT = getEndpoint();
+import { addLogLine } from 'utils/logging';
 
 const DIGITS = new Set(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
 
@@ -294,23 +289,10 @@ function parseHumanDate(humanDate: string): DateValue[] {
 }
 
 async function searchLocation(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     searchPhrase: string
 ): Promise<LocationSearchResponse[]> {
-    try {
-        const resp = await HTTPService.get(
-            `${ENDPOINT}/search/location`,
-            {
-                query: searchPhrase,
-                limit: 4,
-            },
-            {
-                'X-Auth-Token': getToken(),
-            }
-        );
-        return resp.data.results ?? [];
-    } catch (e) {
-        logError(e, 'location search failed');
-    }
+    addLogLine(`attempting to use unimplemented search API`);
     return [];
 }
 


### PR DESCRIPTION
## Test Plan

Can build and run locally. Also tested search. Didn't specifically test this code path but that should be fine because this function currently isn't even called because its caller (`getLocationSuggestions`) is unused,