### PR TITLE
Fix export issue

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -78,7 +78,6 @@ export default function ExportModal(props: Props) {
         exportService.electronAPIs.registerRetryFailedExportListener(
             retryFailedExport
         );
-        exportService.setUpdateExportProgress(updateExportProgress);
     }, []);
 
     useEffect(() => {
@@ -222,6 +221,7 @@ export default function ExportModal(props: Props) {
             await preExportRun();
             updateExportProgress({ current: 0, total: 0 });
             const exportResult = await exportService.exportFiles(
+                updateExportProgress,
                 ExportType.NEW
             );
             await postExportRun(exportResult);
@@ -268,8 +268,8 @@ export default function ExportModal(props: Props) {
                     current: pausedStageProgress.current + progress.current,
                     total: pausedStageProgress.current + progress.total,
                 });
-            exportService.setUpdateExportProgress(updateExportStatsWithOffset);
             const exportResult = await exportService.exportFiles(
+                updateExportStatsWithOffset,
                 ExportType.PENDING
             );
 
@@ -284,12 +284,10 @@ export default function ExportModal(props: Props) {
     const retryFailedExport = async () => {
         try {
             await preExportRun();
-            updateExportProgress({
-                current: 0,
-                total: exportStats.failed,
-            });
+            updateExportProgress({ current: 0, total: exportStats.failed });
 
             const exportResult = await exportService.exportFiles(
+                updateExportProgress,
                 ExportType.RETRY_FAILED
             );
             await postExportRun(exportResult);

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -70,10 +70,10 @@ export default function ExportModal(props: Props) {
     // SIDE EFFECTS
     // ====================
     useEffect(() => {
+        if (!isElectron()) {
+            return;
+        }
         try {
-            if (!isElectron()) {
-                return;
-            }
             setExportFolder(getData(LS_KEYS.EXPORT)?.folder);
 
             exportService.electronAPIs.registerStopExportListener(stopExport);

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -104,7 +104,7 @@ export default function ExportModal(props: Props) {
                     failed: exportInfo?.failedFiles?.length ?? 0,
                 });
                 if (exportInfo?.stage === ExportStage.INPROGRESS) {
-                    resumeExport();
+                    await resumeExport();
                 }
             } catch (e) {
                 logError(
@@ -113,7 +113,7 @@ export default function ExportModal(props: Props) {
                 );
             }
         };
-        main();
+        void main();
     }, [exportFolder]);
 
     useEffect(() => {
@@ -133,7 +133,7 @@ export default function ExportModal(props: Props) {
                     const failedFilesCnt = exportRecord.failedFiles?.length;
                     const syncedFilesCnt = userPersonalFiles.length;
                     if (syncedFilesCnt > exportedFileCnt + failedFilesCnt) {
-                        updateExportProgress({
+                        await updateExportProgress({
                             current: exportedFileCnt + failedFilesCnt,
                             total: syncedFilesCnt,
                         });
@@ -147,11 +147,11 @@ export default function ExportModal(props: Props) {
                                     getExportRecordFileUID(file)
                                 )
                         );
-                        exportService.addFilesQueuedRecord(
+                        await exportService.addFilesQueuedRecord(
                             exportFolder,
                             unExportedFiles
                         );
-                        updateExportStage(ExportStage.PAUSED);
+                        await updateExportStage(ExportStage.PAUSED);
                     }
                 } catch (e) {
                     setExportStage(ExportStage.INIT);
@@ -159,7 +159,7 @@ export default function ExportModal(props: Props) {
                 }
             }
         };
-        main();
+        void main();
     }, [props.show]);
 
     useEffect(() => {
@@ -174,19 +174,21 @@ export default function ExportModal(props: Props) {
         setData(LS_KEYS.EXPORT, { folder: newFolder });
     };
 
-    const updateExportStage = (newStage: ExportStage) => {
+    const updateExportStage = async (newStage: ExportStage) => {
         setExportStage(newStage);
-        exportService.updateExportRecord({ stage: newStage });
+        await exportService.updateExportRecord({ stage: newStage });
     };
 
-    const updateExportTime = (newTime: number) => {
+    const updateExportTime = async (newTime: number) => {
         setLastExportTime(newTime);
-        exportService.updateExportRecord({ lastAttemptTimestamp: newTime });
+        await exportService.updateExportRecord({
+            lastAttemptTimestamp: newTime,
+        });
     };
 
-    const updateExportProgress = (newProgress: ExportProgress) => {
+    const updateExportProgress = async (newProgress: ExportProgress) => {
         setExportProgress(newProgress);
-        exportService.updateExportRecord({ progress: newProgress });
+        await exportService.updateExportRecord({ progress: newProgress });
     };
 
     // ======================
@@ -198,16 +200,16 @@ export default function ExportModal(props: Props) {
         if (!exportFolder) {
             await selectExportDirectory();
         }
-        updateExportStage(ExportStage.INPROGRESS);
+        await updateExportStage(ExportStage.INPROGRESS);
         await sleep(100);
     };
 
     const postExportRun = async (exportResult?: { paused?: boolean }) => {
         if (!exportResult?.paused) {
-            updateExportStage(ExportStage.FINISHED);
+            await updateExportStage(ExportStage.FINISHED);
             await sleep(100);
-            updateExportTime(Date.now());
-            syncExportStatsWithRecord();
+            await updateExportTime(Date.now());
+            await syncExportStatsWithRecord();
         }
     };
 
@@ -236,7 +238,7 @@ export default function ExportModal(props: Props) {
     const startExport = async () => {
         try {
             await preExportRun();
-            updateExportProgress({ current: 0, total: 0 });
+            await updateExportProgress({ current: 0, total: 0 });
             const exportResult = await exportService.exportFiles(
                 ExportType.NEW
             );
@@ -251,7 +253,7 @@ export default function ExportModal(props: Props) {
     const stopExport = async () => {
         try {
             exportService.stopRunningExport();
-            postExportRun();
+            await postExportRun();
         } catch (e) {
             if (e.message !== CustomError.REQUEST_CANCELLED) {
                 logError(e, 'stopExport failed');
@@ -259,11 +261,11 @@ export default function ExportModal(props: Props) {
         }
     };
 
-    const pauseExport = () => {
+    const pauseExport = async () => {
         try {
-            updateExportStage(ExportStage.PAUSED);
+            await updateExportStage(ExportStage.PAUSED);
             exportService.pauseRunningExport();
-            postExportRun({ paused: true });
+            await postExportRun({ paused: true });
         } catch (e) {
             if (e.message !== CustomError.REQUEST_CANCELLED) {
                 logError(e, 'pauseExport failed');
@@ -300,7 +302,10 @@ export default function ExportModal(props: Props) {
     const retryFailedExport = async () => {
         try {
             await preExportRun();
-            updateExportProgress({ current: 0, total: exportStats.failed });
+            await updateExportProgress({
+                current: 0,
+                total: exportStats.failed,
+            });
 
             const exportResult = await exportService.exportFiles(
                 ExportType.RETRY_FAILED

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -1,5 +1,5 @@
 import isElectron from 'is-electron';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import exportService from 'services/exportService';
 import { ExportProgress, ExportStats } from 'types/export';
 import { getLocalFiles } from 'services/fileService';
@@ -32,6 +32,7 @@ import { OverflowMenuOption } from './OverflowMenu/option';
 import { convertBytesToHumanReadable } from 'utils/file/size';
 import { CustomError } from 'utils/error';
 import { getLocalUserDetails } from 'utils/user';
+import { AppContext } from 'pages/_app';
 
 const ExportFolderPathContainer = styled('span')`
     white-space: nowrap;
@@ -49,6 +50,8 @@ interface Props {
     onHide: () => void;
 }
 export default function ExportModal(props: Props) {
+    const appContext = useContext(AppContext);
+
     const userDetails = useMemo(() => getLocalUserDetails(), []);
     const [exportStage, setExportStage] = useState(ExportStage.INIT);
     const [exportFolder, setExportFolder] = useState('');
@@ -220,6 +223,7 @@ export default function ExportModal(props: Props) {
                 updateExportFolder(newFolder);
             }
         } catch (e) {
+            appContext.somethingWentWrong();
             logError(e, 'selectExportDirectory failed');
         }
     };
@@ -245,6 +249,7 @@ export default function ExportModal(props: Props) {
             await postExportRun(exportResult);
         } catch (e) {
             if (e.message !== CustomError.REQUEST_CANCELLED) {
+                appContext.somethingWentWrong();
                 logError(e, 'startExport failed');
             }
         }
@@ -256,6 +261,7 @@ export default function ExportModal(props: Props) {
             await postExportRun();
         } catch (e) {
             if (e.message !== CustomError.REQUEST_CANCELLED) {
+                appContext.somethingWentWrong();
                 logError(e, 'stopExport failed');
             }
         }
@@ -268,6 +274,7 @@ export default function ExportModal(props: Props) {
             await postExportRun({ paused: true });
         } catch (e) {
             if (e.message !== CustomError.REQUEST_CANCELLED) {
+                appContext.somethingWentWrong();
                 logError(e, 'pauseExport failed');
             }
         }
@@ -294,6 +301,7 @@ export default function ExportModal(props: Props) {
             await postExportRun(exportResult);
         } catch (e) {
             if (e.message !== CustomError.REQUEST_CANCELLED) {
+                appContext.somethingWentWrong();
                 logError(e, 'resumeExport failed');
             }
         }
@@ -313,6 +321,7 @@ export default function ExportModal(props: Props) {
             await postExportRun(exportResult);
         } catch (e) {
             if (e.message !== CustomError.REQUEST_CANCELLED) {
+                appContext.somethingWentWrong();
                 logError(e, 'retryFailedExport failed');
             }
         }

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -81,6 +81,7 @@ export default function ExportModal(props: Props) {
             exportService.electronAPIs.registerRetryFailedExportListener(
                 retryFailedExport
             );
+            exportService.setUpdateExportProgress(updateExportProgress);
         } catch (e) {
             logError(e, 'error while registering export listeners');
         }
@@ -237,7 +238,6 @@ export default function ExportModal(props: Props) {
             await preExportRun();
             updateExportProgress({ current: 0, total: 0 });
             const exportResult = await exportService.exportFiles(
-                updateExportProgress,
                 ExportType.NEW
             );
             await postExportRun(exportResult);
@@ -284,8 +284,8 @@ export default function ExportModal(props: Props) {
                     current: pausedStageProgress.current + progress.current,
                     total: pausedStageProgress.current + progress.total,
                 });
+            exportService.setUpdateExportProgress(updateExportStatsWithOffset);
             const exportResult = await exportService.exportFiles(
-                updateExportStatsWithOffset,
                 ExportType.PENDING
             );
 
@@ -303,7 +303,6 @@ export default function ExportModal(props: Props) {
             updateExportProgress({ current: 0, total: exportStats.failed });
 
             const exportResult = await exportService.exportFiles(
-                updateExportProgress,
                 ExportType.RETRY_FAILED
             );
             await postExportRun(exportResult);

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -195,13 +195,11 @@ export default function ExportModal(props: Props) {
     };
 
     const selectExportDirectory = async () => {
-        try {
-            const newFolder = await exportService.selectExportDirectory();
-            if (newFolder) {
-                updateExportFolder(newFolder);
-            }
-        } catch (e) {
-            logError(e, 'selectExportDirectory failed');
+        const newFolder = await exportService.selectExportDirectory();
+        if (newFolder) {
+            updateExportFolder(newFolder);
+        } else {
+            throw Error(CustomError.REQUEST_CANCELLED);
         }
     };
 

--- a/src/components/Sidebar/HelpSection.tsx
+++ b/src/components/Sidebar/HelpSection.tsx
@@ -46,7 +46,9 @@ export default function HelpSection() {
                 <div style={{ display: 'flex' }}>
                     {constants.EXPORT}
                     <div style={{ width: '20px' }} />
-                    {exportService.isExportInProgress() && <EnteSpinner />}
+                    {exportService.isExportInProgress() && (
+                        <EnteSpinner size="20px" />
+                    )}
                 </div>
             </SidebarButton>
             <ExportModal

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -22,7 +22,7 @@ export default function Sidebar({
     closeSidebar,
 }: Iprops) {
     return (
-        <DrawerSidebar open={sidebarView} onClose={closeSidebar}>
+        <DrawerSidebar open={sidebarView} onClose={closeSidebar} keepMounted>
             <HeaderSection closeSidebar={closeSidebar} />
             <Divider />
             <UserDetailsSection sidebarView={sidebarView} />

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -170,7 +170,7 @@ class ExportService {
             return resp;
         } catch (e) {
             logError(e, 'exportFiles failed');
-            return { paused: false };
+            throw e;
         } finally {
             this.exportInProgress = null;
         }

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -163,11 +163,12 @@ class ExportService {
                 exportDir
             );
             const resp = await this.exportInProgress;
-            this.exportInProgress = null;
             return resp;
         } catch (e) {
             logError(e, 'exportFiles failed');
             return { paused: false };
+        } finally {
+            this.exportInProgress = null;
         }
     }
 

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -167,11 +167,12 @@ class ExportService {
                 exportDir
             );
             const resp = await this.exportInProgress;
-            this.exportInProgress = null;
             return resp;
         } catch (e) {
             logError(e, 'exportFiles failed');
             return { paused: false };
+        } finally {
+            this.exportInProgress = null;
         }
     }
 

--- a/src/utils/export/index.ts
+++ b/src/utils/export/index.ts
@@ -121,10 +121,9 @@ export const getExportFailedFiles = (
     return filesToExport;
 };
 
-export const dedupe = (files: any[]) => {
+export const dedupe = (files: string[]) => {
     const fileSet = new Set(files);
-    const dedupedArray = new Array(...fileSet);
-    return dedupedArray;
+    return Array.from(fileSet);
 };
 
 export const getGoogleLikeMetadataFile = (


### PR DESCRIPTION
## Description
- added `keepMounted` prop to sidebar, to avoid dismounting exportModal
- fix enteSpinner for export in progress size
- fix possible StackOverflow issue, caused by spreading parameter in `new Array(...fileSet);` 
- fixed exportInProgress not reset on error  


## Test Plan

- [x] test export progress is shown progress properly, when sidebar closed and opened
- [x] confirm ente spinner size
