### PR TITLE
Add password strength check

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "workbox-strategies": "^6.1.5",
     "workbox-window": "^6.1.5",
     "xml-js": "^1.6.11",
-    "yup": "^0.29.3"
+    "yup": "^0.29.3",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^13.1.6",
@@ -96,6 +97,7 @@
     "@types/styled-components": "^5.1.25",
     "@types/wicg-file-system-access": "^2020.9.5",
     "@types/yup": "^0.29.7",
+    "@types/zxcvbn": "^4.4.1",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "eslint": "^8.28.0",
     "eslint-config-next": "^13.0.6",

--- a/src/components/PasswordStrength.tsx
+++ b/src/components/PasswordStrength.tsx
@@ -1,0 +1,37 @@
+import { Typography } from '@mui/material';
+import { PasswordStrength } from 'constants/crypto';
+import { useMemo } from 'react';
+import { estimatePasswordStrength } from 'utils/crypto';
+import constants from 'utils/strings/constants';
+import { FlexWrapper } from './Container';
+
+export const PasswordStrengthHint = ({
+    password,
+}: {
+    password: string;
+}): JSX.Element => {
+    const passwordStrength = useMemo(
+        () => estimatePasswordStrength(password),
+        [password]
+    );
+    return (
+        <FlexWrapper mt={'8px'} mb={'4px'}>
+            <Typography
+                variant="body2"
+                sx={(theme) => ({
+                    color:
+                        passwordStrength === PasswordStrength.WEAK
+                            ? theme.palette.danger.main
+                            : passwordStrength === PasswordStrength.MODERATE
+                            ? theme.palette.warning.main
+                            : theme.palette.accent.main,
+                })}
+                textAlign={'left'}
+                flex={1}>
+                {password
+                    ? constants.PASSPHRASE_STRENGTH(passwordStrength)
+                    : ''}
+            </Typography>
+        </FlexWrapper>
+    );
+};

--- a/src/components/SetPasswordForm.tsx
+++ b/src/components/SetPasswordForm.tsx
@@ -40,10 +40,10 @@ function SetPasswordForm(props: SetPasswordFormProps) {
         setLoading(true);
         try {
             const { passphrase, confirm } = values;
-            if (passphrase !== confirm) {
-                setFieldError('confirm', constants.PASSPHRASE_MATCH_ERROR);
-            } else {
+            if (passphrase === confirm) {
                 await props.callback(passphrase, setFieldError);
+            } else {
+                setFieldError('confirm', constants.PASSPHRASE_MATCH_ERROR);
             }
         } catch (e) {
             setFieldError('confirm', `${constants.UNKNOWN_ERROR} ${e.message}`);

--- a/src/components/SetPasswordForm.tsx
+++ b/src/components/SetPasswordForm.tsx
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import * as Yup from 'yup';
 import SubmitButton from './SubmitButton';
 import { Box, Input, TextField, Typography } from '@mui/material';
+import { isWeakPassword } from 'utils/crypto';
 
 export interface SetPasswordFormProps {
     userEmail: string;
@@ -38,10 +39,12 @@ function SetPasswordForm(props: SetPasswordFormProps) {
         setLoading(true);
         try {
             const { passphrase, confirm } = values;
-            if (passphrase === confirm) {
-                await props.callback(passphrase, setFieldError);
-            } else {
+            if (passphrase !== confirm) {
                 setFieldError('confirm', constants.PASSPHRASE_MATCH_ERROR);
+            } else if (isWeakPassword(passphrase)) {
+                setFieldError('confirm', constants.PASSPHRASE_STRENGTH_WEAK);
+            } else {
+                await props.callback(passphrase, setFieldError);
             }
         } catch (e) {
             setFieldError('confirm', `${constants.UNKNOWN_ERROR} ${e.message}`);

--- a/src/components/SetPasswordForm.tsx
+++ b/src/components/SetPasswordForm.tsx
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import * as Yup from 'yup';
 import SubmitButton from './SubmitButton';
 import { Box, Input, TextField, Typography } from '@mui/material';
+import { PasswordStrengthHint } from './PasswordStrength';
 import { isWeakPassword } from 'utils/crypto';
 
 export interface SetPasswordFormProps {
@@ -41,8 +42,6 @@ function SetPasswordForm(props: SetPasswordFormProps) {
             const { passphrase, confirm } = values;
             if (passphrase !== confirm) {
                 setFieldError('confirm', constants.PASSPHRASE_MATCH_ERROR);
-            } else if (isWeakPassword(passphrase)) {
-                setFieldError('confirm', constants.PASSPHRASE_STRENGTH_WEAK);
             } else {
                 await props.callback(passphrase, setFieldError);
             }
@@ -104,6 +103,7 @@ function SetPasswordForm(props: SetPasswordFormProps) {
                         error={Boolean(errors.confirm)}
                         helperText={errors.confirm}
                     />
+                    <PasswordStrengthHint password={values.passphrase} />
 
                     <Typography my={2} variant="body2">
                         {constants.PASSPHRASE_DISCLAIMER()}
@@ -114,6 +114,7 @@ function SetPasswordForm(props: SetPasswordFormProps) {
                             sx={{ my: 0 }}
                             loading={loading}
                             buttonText={props.buttonText}
+                            disabled={isWeakPassword(values.passphrase)}
                         />
                         {loading && (
                             <Typography

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -28,6 +28,7 @@ import FormPaperTitle from './Form/FormPaper/Title';
 import LinkButton from './pages/gallery/LinkButton';
 import FormPaperFooter from './Form/FormPaper/Footer';
 import VerticallyCentered from './Container';
+import { PasswordStrengthHint } from './PasswordStrength';
 
 interface FormValues {
     email: string;
@@ -51,9 +52,6 @@ export default function SignUp(props: SignUpProps) {
         try {
             if (passphrase !== confirm) {
                 setFieldError('confirm', constants.PASSPHRASE_MATCH_ERROR);
-                return;
-            } else if (isWeakPassword(passphrase)) {
-                setFieldError('confirm', constants.PASSPHRASE_STRENGTH_WEAK);
                 return;
             }
             setLoading(true);
@@ -162,6 +160,9 @@ export default function SignUp(props: SignUpProps) {
                                 helperText={errors.confirm}
                                 disabled={loading}
                             />
+                            <PasswordStrengthHint
+                                password={values.passphrase}
+                            />
                             <FormGroup sx={{ width: '100%' }}>
                                 <FormControlLabel
                                     sx={{
@@ -189,7 +190,10 @@ export default function SignUp(props: SignUpProps) {
                                 sx={{ my: 0 }}
                                 buttonText={constants.CREATE_ACCOUNT}
                                 loading={loading}
-                                disabled={!acceptTerms}
+                                disabled={
+                                    !acceptTerms ||
+                                    isWeakPassword(values.passphrase)
+                                }
                             />
                             {loading && (
                                 <Typography

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -9,6 +9,7 @@ import SubmitButton from 'components/SubmitButton';
 import {
     generateAndSaveIntermediateKeyAttributes,
     generateKeyAttributes,
+    isWeakPassword,
     saveKeyInSessionStore,
 } from 'utils/crypto';
 import { setJustSignedUp } from 'utils/storage';
@@ -50,6 +51,9 @@ export default function SignUp(props: SignUpProps) {
         try {
             if (passphrase !== confirm) {
                 setFieldError('confirm', constants.PASSPHRASE_MATCH_ERROR);
+                return;
+            } else if (isWeakPassword(passphrase)) {
+                setFieldError('confirm', constants.PASSPHRASE_STRENGTH_WEAK);
                 return;
             }
             setLoading(true);

--- a/src/constants/crypto/index.ts
+++ b/src/constants/crypto/index.ts
@@ -1,1 +1,7 @@
 export const ENCRYPTION_CHUNK_SIZE = 4 * 1024 * 1024;
+
+export enum PasswordStrength {
+    WEAK,
+    MODERATE,
+    STRONG,
+}

--- a/src/themes/darkThemeOptions.tsx
+++ b/src/themes/darkThemeOptions.tsx
@@ -33,12 +33,14 @@ declare module '@mui/material/styles' {
         backdrop: PaletteColor;
         blur: BlurStrength;
         danger: PaletteColor;
+        caution: PaletteColor;
         stroke: TypeText;
         fixed: FixedColor;
     }
     interface PaletteOptions {
         accent?: PaletteColorOptions;
         danger?: PaletteColorOptions;
+        caution?: PaletteColorOptions;
         fill?: PaletteColorOptions;
         backdrop?: PaletteColorOptions;
         blur?: BlurStrengthOptions;
@@ -296,6 +298,9 @@ const darkThemeOptions = createTheme({
 
         danger: {
             main: '#EA3f3f',
+        },
+        caution: {
+            main: '#FFC247',
         },
         stroke: {
             primary: '#ffffff',

--- a/src/utils/crypto/index.ts
+++ b/src/utils/crypto/index.ts
@@ -213,3 +213,42 @@ export async function decryptDeleteAccountChallenge(
     const utf8DecryptedChallenge = atob(b64DecryptedChallenge);
     return utf8DecryptedChallenge;
 }
+
+// Port of https://github.com/JinHoSo/flutter-password-strength/blob/master/lib/src/estimate_bruteforce_strength.dart
+// used in mobile app.
+function estimatePasswordStrength(password: string) {
+    if (!password) {
+        return 0.0;
+    }
+
+    // Check which types of characters are used and create an opinionated bonus.
+    let charsetBonus: number;
+    if (/^[a-z]*$/.test(password)) {
+        charsetBonus = 1.0;
+    } else if (/^[a-z0-9]*$/.test(password)) {
+        charsetBonus = 1.2;
+    } else if (/^[a-zA-Z]*$/.test(password)) {
+        charsetBonus = 1.3;
+    } else if (/^[a-z\-_!?]*$/.test(password)) {
+        charsetBonus = 1.3;
+    } else if (/^[a-zA-Z0-9]*$/.test(password)) {
+        charsetBonus = 1.5;
+    } else {
+        charsetBonus = 1.8;
+    }
+
+    const logisticFunction = (x: number) => {
+        return 1.0 / (1.0 + Math.exp(-x));
+    };
+
+    const curve = (x: number) => {
+        return logisticFunction(x / 3.0 - 4.0);
+    };
+
+    return curve(password.length * charsetBonus);
+}
+
+export function isWeakPassword(password: string) {
+    // used the strength color green as threshold
+    return estimatePasswordStrength(password) < 0.76;
+}

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -998,6 +998,7 @@ const englishConstants = {
         'I understand, and wish to allow ente to process face geometry',
     LABS: 'Labs',
     YOURS: 'yours',
+    PASSPHRASE_STRENGTH_WEAK: 'Password strength: weak',
 };
 
 export default englishConstants;

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -7,6 +7,7 @@ import { SuggestionType } from 'types/search';
 import { formatNumberWithCommas } from '.';
 import { FACE_SEARCH_PRIVACY_POLICY_LINK } from 'constants/urls';
 import { EnteLogo } from 'components/EnteLogo';
+import { PasswordStrength } from 'constants/crypto';
 /**
  * Global English constants.
  */
@@ -998,7 +999,14 @@ const englishConstants = {
         'I understand, and wish to allow ente to process face geometry',
     LABS: 'Labs',
     YOURS: 'yours',
-    PASSPHRASE_STRENGTH_WEAK: 'Password strength: weak',
+    PASSPHRASE_STRENGTH: (strength: PasswordStrength) =>
+        `Password strength: ${
+            strength === PasswordStrength.STRONG
+                ? 'Strong'
+                : strength === PasswordStrength.MODERATE
+                ? 'Moderate'
+                : 'Weak'
+        }`,
 };
 
 export default englishConstants;

--- a/yarn.lock
+++ b/yarn.lock
@@ -985,6 +985,11 @@
   resolved "https://registry.npmjs.org/@types/yup/-/yup-0.29.13.tgz"
   integrity sha512-qRyuv+P/1t1JK1rA+elmK1MmCL1BapEzKKfbEhDBV/LMMse4lmhZ/XbgETI39JveDJRpLjmToOI6uFtMW/WR2g==
 
+"@types/zxcvbn@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@types/zxcvbn/-/zxcvbn-4.4.1.tgz#46e42cbdcee681b22181478feaf4af2bc4c1abd2"
+  integrity sha512-3NoqvZC2W5gAC5DZbTpCeJ251vGQmgcWIHQJGq2J240HY6ErQ9aWKkwfoKJlHLx+A83WPNTZ9+3cd2ILxbvr1w==
+
 "@typescript-eslint/eslint-plugin@^5.43.0":
   version "5.48.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.1.tgz#deee67e399f2cb6b4608c935777110e509d8018c"
@@ -4878,3 +4883,8 @@ zlibjs@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/zlibjs/-/zlibjs-0.3.1.tgz#50197edb28a1c42ca659cc8b4e6a9ddd6d444554"
   integrity sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==
+
+zxcvbn@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
+  integrity sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==


### PR DESCRIPTION
## Description

- add password strength check validation to signup and password change flow 
- added UI to show that the current entered password strength
- weak passwords are not allowed 

the score scale from the package readme 
```
result.score      # Integer from 0-4 (useful for implementing a strength bar)

  0 # too guessable: risky password. (guesses < 10^3)

  1 # very guessable: protection from throttled online attacks. (guesses < 10^6)

  2 # somewhat guessable: protection from unthrottled online attacks. (guesses < 10^8)

  3 # safely unguessable: moderate protection from offline slow-hash scenario. (guesses < 10^10)

  4 # very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)
```

Have used 
```
1. Weak = 0-2
2. Moderate = 3
3. Strong = 4
```


signup page 
<img width="544" alt="image" src="https://user-images.githubusercontent.com/46242073/221826362-d36b6fb2-8005-4245-9104-e501e2328fa7.png">

<img width="409" alt="image" src="https://user-images.githubusercontent.com/46242073/221826448-92812121-4360-4611-9126-62f4715ddcee.png">

<img width="458" alt="image" src="https://user-images.githubusercontent.com/46242073/221826502-f8bb643a-fc0f-4101-a1c7-3cb9a01d646b.png">


change password page 
<img width="571" alt="image" src="https://user-images.githubusercontent.com/46242073/221826751-9f11ea59-896b-473d-89b0-57b3f764b6c4.png">

<img width="588" alt="image" src="https://user-images.githubusercontent.com/46242073/221826837-04ef02d8-1e0f-4122-b86b-a4b3a5aac9e2.png">


## Test Plan

tested locally the change and UI for signup and change password flow 
