### PR TITLE
Refactor CryptoWorker 

### DIFF
--- a/src/utils/crypto/libsodium.ts
+++ b/src/utils/crypto/libsodium.ts
@@ -189,6 +189,7 @@ export async function encryptToB64(data: string, key: string) {
 }
 
 export async function generateKeyAndEncryptToB64(data: string) {
+    await sodium.ready;
     const key = sodium.crypto_secretbox_keygen();
     return await encryptToB64(data, await toB64(key));
 }


### PR DESCRIPTION
## Description
- add missing `sodium.ready` check  
 
## Test Plan

found and tested with desktop app where this was the first crypto function to run hence throwing the sodium not ready error 
