### PR TITLE
fix missing await issue

### DIFF
--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -87,7 +87,6 @@ class ExportService {
         exportType: ExportType
     ) {
         try {
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             if (this.exportInProgress) {
                 this.electronAPIs.sendNotification(
                     ExportNotification.IN_PROGRESS

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -87,6 +87,7 @@ class ExportService {
         exportType: ExportType
     ) {
         try {
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             if (this.exportInProgress) {
                 this.electronAPIs.sendNotification(
                     ExportNotification.IN_PROGRESS
@@ -206,7 +207,7 @@ class ExportService {
             }
             this.stopExport = false;
             this.pauseExport = false;
-            this.addFilesQueuedRecord(exportDir, files);
+            await this.addFilesQueuedRecord(exportDir, files);
             const failedFileCount = 0;
 
             this.electronAPIs.showOnTray({
@@ -456,7 +457,7 @@ class ExportService {
         if (file.metadata.fileType === FILE_TYPE.LIVE_PHOTO) {
             await this.exportMotionPhoto(fileStream, file, collectionPath);
         } else {
-            this.saveMediaFile(collectionPath, fileSaveName, fileStream);
+            await this.saveMediaFile(collectionPath, fileSaveName, fileStream);
             await this.saveMetadataFile(collectionPath, fileSaveName, file);
         }
     }
@@ -474,7 +475,7 @@ class ExportService {
             motionPhoto.imageNameTitle,
             file.id
         );
-        this.saveMediaFile(collectionPath, imageSaveName, imageStream);
+        await this.saveMediaFile(collectionPath, imageSaveName, imageStream);
         await this.saveMetadataFile(collectionPath, imageSaveName, file);
 
         const videoStream = generateStreamFromArrayBuffer(motionPhoto.video);

--- a/src/utils/sentry/index.ts
+++ b/src/utils/sentry/index.ts
@@ -2,46 +2,33 @@ import * as Sentry from '@sentry/nextjs';
 import { addLogLine } from 'utils/logging';
 import { getSentryUserID } from 'utils/user';
 
-export const logError = (
+export const logError = async (
     error: any,
     msg: string,
     info?: Record<string, unknown>,
     skipAddLogLine = false
 ) => {
-    const main = async () => {
-        try {
-            if (isErrorUnnecessaryForSentry(error)) {
-                return;
-            }
-            const err = errorWithContext(error, msg);
-            if (!skipAddLogLine) {
-                addLogLine(
-                    `error: ${error?.name} ${error?.message} ${
-                        error?.stack
-                    } msg: ${msg} ${
-                        info ? `info: ${JSON.stringify(info)}` : ''
-                    }`
-                );
-            }
-            Sentry.captureException(err, {
-                level: Sentry.Severity.Info,
-                user: { id: await getSentryUserID() },
-                contexts: {
-                    ...(info && {
-                        info: info,
-                    }),
-                    rootCause: {
-                        message: error?.message,
-                        completeError: error,
-                    },
-                },
-            });
-        } catch (e) {
-            addLogLine('error in logError', e);
-            // ignore
-        }
-    };
-    void main();
+    if (isErrorUnnecessaryForSentry(error)) {
+        return;
+    }
+    const err = errorWithContext(error, msg);
+    if (!skipAddLogLine) {
+        addLogLine(
+            `error: ${error?.name} ${error?.message} ${
+                error?.stack
+            } msg: ${msg} ${info ? `info: ${JSON.stringify(info)}` : ''}`
+        );
+    }
+    Sentry.captureException(err, {
+        level: Sentry.Severity.Info,
+        user: { id: await getSentryUserID() },
+        contexts: {
+            ...(info && {
+                info: info,
+            }),
+            rootCause: { message: error?.message, completeError: error },
+        },
+    });
 };
 
 // copy of errorWithContext to prevent importing error util


### PR DESCRIPTION
## Description
- await missing on `addFilesQueuedRecord`, which might be the reason for the user error 
```
 error: TypeError Cannot read properties of undefined (reading 'filter') TypeError: Cannot read properties of undefined (reading 'filter')
    at Object.addFileExportedRecord (ente://app/_next/static/chunks/5105-111b35ea73525f6c.js:1:117081)
    at async Object.fileExporter (ente://app/_next/static/chunks/5105-111b35ea73525f6c.js:1:116259)
    at async Object.exportFiles (ente://app/_next/static/chunks/5105-111b35ea73525f6c.js:1:115237)
```
which was pointing to this line
>exportRecord.queuedFiles = exportRecord.queuedFiles.filter(

https://github.com/ente-io/bada-frame/blob/b3ec5423a64ad831f37bd3e5f107506239898be0/src/services/exportService.ts#L294

> await this.addFilesQueuedRecord(exportDir, files);
https://github.com/ente-io/photos-web/pull/965/commits/407bd9fd9a3fcb2f53da5fb54941e92d7f6e8376#diff-a7dd4b8fc0c14d0061c9c22a9d567615649378063b25d427b53aea88e3e707ecR210

so, this could be the cause as the promise was not awaited, so the promise might not have been resolved by the time the user reached the  `exportRecord.queuedFiles.filter` line


added `await sleep(100000);` to the `addFilesQueuedRecord` to test the hypothesis 
```   
async addFilesQueuedRecord(folder: string, files: EnteFile[]) {
        await sleep(100000);
        const exportRecord = await this.getExportRecord(folder);
        exportRecord.queuedFiles = files.map(getExportRecordFileUID);
        await this.updateExportRecord(exportRecord, folder);
    } 
 ```
 
This made sure the promise is definitely not resolved before a file is exported, and it threw the same error.

> error: TypeError Cannot read properties of undefined (reading 'filter') TypeError: Cannot read properties of undefined (reading 'filter')
    at ExportService.addFileExportedRecord (webpack-internal:///./src/services/exportService.ts:183:61)
    at async ExportService.fileExporter (webpack-internal:///./src/services/exportService.ts:138:21)
    at async ExportService.exportFiles (webpack-internal:///./src/services/exportService.ts:86:26)
    at async startExport (webpack-internal:///./src/components/ExportModal.tsx:251:34) msg: exportFiles failed 

## Test Plan

confirmed that the issue error doesn't happen after the fix, the export doesn't start before that promise is resolved 

    
    