### PR TITLE
Fix all promise related eslint issue for export

### DIFF
--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -49,6 +49,7 @@ import { User } from 'types/user';
 import { FILE_TYPE, TYPE_JPEG, TYPE_JPG } from 'constants/file';
 import { ExportType, ExportNotification, RecordType } from 'constants/export';
 import { ElectronAPIs } from 'types/electron';
+import { CustomError } from 'utils/error';
 
 const LATEST_EXPORT_VERSION = 1;
 const EXPORT_RECORD_FILE_NAME = 'export_status.json';
@@ -83,10 +84,11 @@ class ExportService {
         this.pauseExport = true;
     }
     async exportFiles(
-        updateProgress: (progress: ExportProgress) => void,
+        updateProgress: (progress: ExportProgress) => Promise<void>,
         exportType: ExportType
     ) {
         try {
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             if (this.exportInProgress) {
                 this.electronAPIs.sendNotification(
                     ExportNotification.IN_PROGRESS
@@ -177,7 +179,7 @@ class ExportService {
         newCollections: Collection[],
         renamedCollections: Collection[],
         collectionIDPathMap: CollectionIDPathMap,
-        updateProgress: (progress: ExportProgress) => void,
+        updateProgress: (progress: ExportProgress) => Promise<void>,
         exportDir: string
     ): Promise<{ paused: boolean }> {
         try {
@@ -212,7 +214,7 @@ class ExportService {
             this.electronAPIs.showOnTray({
                 export_progress: `0 / ${files.length} files exported`,
             });
-            updateProgress({
+            await updateProgress({
                 current: 0,
                 total: files.length,
             });
@@ -239,6 +241,12 @@ class ExportService {
                         RecordType.SUCCESS
                     );
                 } catch (e) {
+                    if (
+                        e.message ===
+                        CustomError.ADD_FILE_EXPORTED_RECORD_FAILED
+                    ) {
+                        throw e;
+                    }
                     await this.addFileExportedRecord(
                         exportDir,
                         file,
@@ -255,7 +263,10 @@ class ExportService {
                         files.length
                     } files exported`,
                 });
-                updateProgress({ current: index + 1, total: files.length });
+                await updateProgress({
+                    current: index + 1,
+                    total: files.length,
+                });
             }
             if (this.stopExport) {
                 this.electronAPIs.sendNotification(ExportNotification.ABORT);
@@ -266,7 +277,7 @@ class ExportService {
             } else if (failedFileCount > 0) {
                 this.electronAPIs.sendNotification(ExportNotification.FAILED);
                 this.electronAPIs.showOnTray({
-                    retry_export: `export failed - retry export`,
+                    retry_export: `Retry failed export`,
                 });
             } else {
                 this.electronAPIs.sendNotification(ExportNotification.FINISH);
@@ -289,32 +300,37 @@ class ExportService {
         file: EnteFile,
         type: RecordType
     ) {
-        const fileUID = getExportRecordFileUID(file);
-        const exportRecord = await this.getExportRecord(folder);
-        exportRecord.queuedFiles = exportRecord.queuedFiles.filter(
-            (queuedFilesUID) => queuedFilesUID !== fileUID
-        );
-        if (type === RecordType.SUCCESS) {
-            if (!exportRecord.exportedFiles) {
-                exportRecord.exportedFiles = [];
+        try {
+            const fileUID = getExportRecordFileUID(file);
+            const exportRecord = await this.getExportRecord(folder);
+            exportRecord.queuedFiles = exportRecord.queuedFiles.filter(
+                (queuedFilesUID) => queuedFilesUID !== fileUID
+            );
+            if (type === RecordType.SUCCESS) {
+                if (!exportRecord.exportedFiles) {
+                    exportRecord.exportedFiles = [];
+                }
+                exportRecord.exportedFiles.push(fileUID);
+                exportRecord.failedFiles &&
+                    (exportRecord.failedFiles = exportRecord.failedFiles.filter(
+                        (FailedFileUID) => FailedFileUID !== fileUID
+                    ));
+            } else {
+                if (!exportRecord.failedFiles) {
+                    exportRecord.failedFiles = [];
+                }
+                if (!exportRecord.failedFiles.find((x) => x === fileUID)) {
+                    exportRecord.failedFiles.push(fileUID);
+                }
             }
-            exportRecord.exportedFiles.push(fileUID);
-            exportRecord.failedFiles &&
-                (exportRecord.failedFiles = exportRecord.failedFiles.filter(
-                    (FailedFileUID) => FailedFileUID !== fileUID
-                ));
-        } else {
-            if (!exportRecord.failedFiles) {
-                exportRecord.failedFiles = [];
-            }
-            if (!exportRecord.failedFiles.find((x) => x === fileUID)) {
-                exportRecord.failedFiles.push(fileUID);
-            }
+            exportRecord.exportedFiles = dedupe(exportRecord.exportedFiles);
+            exportRecord.queuedFiles = dedupe(exportRecord.queuedFiles);
+            exportRecord.failedFiles = dedupe(exportRecord.failedFiles);
+            await this.updateExportRecord(exportRecord, folder);
+        } catch (e) {
+            logError(e, 'addFileExportedRecord failed');
+            throw Error(CustomError.ADD_FILE_EXPORTED_RECORD_FAILED);
         }
-        exportRecord.exportedFiles = dedupe(exportRecord.exportedFiles);
-        exportRecord.queuedFiles = dedupe(exportRecord.queuedFiles);
-        exportRecord.failedFiles = dedupe(exportRecord.failedFiles);
-        await this.updateExportRecord(exportRecord, folder);
     }
 
     async addCollectionExportedRecord(
@@ -354,6 +370,7 @@ class ExportService {
             );
         } catch (e) {
             logError(e, 'error updating Export Record');
+            throw e;
         }
     }
 
@@ -372,6 +389,7 @@ class ExportService {
             }
         } catch (e) {
             logError(e, 'export Record JSON parsing failed ');
+            throw e;
         }
     }
 

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -277,7 +277,7 @@ class ExportService {
             } else if (failedFileCount > 0) {
                 this.electronAPIs.sendNotification(ExportNotification.FAILED);
                 this.electronAPIs.showOnTray({
-                    retry_export: `Retry failed export`,
+                    retry_export: `Retry failed exports`,
                 });
             } else {
                 this.electronAPIs.sendNotification(ExportNotification.FINISH);

--- a/src/utils/error/index.ts
+++ b/src/utils/error/index.ts
@@ -55,6 +55,7 @@ export const CustomError = {
         'Windows native image processing is not supported',
     NETWORK_ERROR: 'Network Error',
     NOT_FILE_OWNER: 'not file owner',
+    ADD_FILE_EXPORTED_RECORD_FAILED: 'add file exported record failed',
 };
 
 export function parseUploadErrorCodes(error) {


### PR DESCRIPTION
## Description

- enabled the promise eslint rule temporarily, to check and fix it for export flow only  
<img width="2135" alt="image" src="https://user-images.githubusercontent.com/46242073/222359475-fe437ba6-42c4-4059-b403-868305f7ad32.png">

### Changes Done
- added missing try catch wrappers around code in useEffect block, which could cause uncaught expectations 
        - https://github.com/ente-io/photos-web/pull/967/files#diff-ce20bcf03cbfdc73a257b87d177ed96355d0cb822ab638e246f65ab285caaa1bR73-R86
        - https://github.com/ente-io/photos-web/pull/967/files#diff-ce20bcf03cbfdc73a257b87d177ed96355d0cb822ab638e246f65ab285caaa1bR94-R109
- `void` main() -> void is added for when we intentionally want to not await a function. 
        This is done because useEffect function can't be async and hence we can't use inside `await` it
        https://github.com/ente-io/photos-web/pull/967/files#diff-ce20bcf03cbfdc73a257b87d177ed96355d0cb822ab638e246f65ab285caaa1bR112
- added awaited to places where it was missed 
- made handler function which can be passed as `eventHandler`  , because event handler expects the function return type to be `void` (not event `Promise<void>` will work ), so this handler wraps the actual function and use `void` to avoid awaiting on them (making the handler synchronous )
https://github.com/ente-io/photos-web/pull/967/files#diff-ce20bcf03cbfdc73a257b87d177ed96355d0cb822ab638e246f65ab285caaa1bR320-R335
- added a eslint disable where we were using a `promise` variable as a check for whether the export was in progress,
this is a valid use case, so disabling the error is fine 
https://github.com/ente-io/photos-web/pull/967/files#diff-a7dd4b8fc0c14d0061c9c22a9d567615649378063b25d427b53aea88e3e707ecR91
- started throwing errors from some functions which was swallowing them, but throwing them and handling them in the caller is a  better solution.
      - https://github.com/ente-io/photos-web/pull/967/files#diff-a7dd4b8fc0c14d0061c9c22a9d567615649378063b25d427b53aea88e3e707ecR373
      - https://github.com/ente-io/photos-web/pull/967/files#diff-a7dd4b8fc0c14d0061c9c22a9d567615649378063b25d427b53aea88e3e707ecR392
- update error handling at some places, 
- these two, now have their try catch wrapper, their internal code has not changed, they just log the error in the catch blocks and rethrow the Error forward (or throw some custom error )
    - https://github.com/ente-io/photos-web/pull/967/files#diff-a7dd4b8fc0c14d0061c9c22a9d567615649378063b25d427b53aea88e3e707ecR299-R328
    - https://github.com/ente-io/photos-web/pull/967/files#diff-a7dd4b8fc0c14d0061c9c22a9d567615649378063b25d427b53aea88e3e707ecR445-R483

## Test Plan

- After the changes, the eslint error was gone 
- In general, monkey tested the export operations (pause, resume, stop, resync, retry failed )
