### PR TITLE
reset sidebar scroll on close

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import ShortcutSection from './ShortcutSection';
 import UtilitySection from './UtilitySection';
@@ -21,8 +21,19 @@ export default function Sidebar({
     sidebarView,
     closeSidebar,
 }: Iprops) {
+    const drawerSidebarPaperRef = React.useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        if (!sidebarView && drawerSidebarPaperRef.current) {
+            drawerSidebarPaperRef.current.scrollTop = 0;
+        }
+    }, [sidebarView]);
+
     return (
-        <DrawerSidebar open={sidebarView} onClose={closeSidebar} keepMounted>
+        <DrawerSidebar
+            open={sidebarView}
+            onClose={closeSidebar}
+            keepMounted
+            PaperProps={{ ref: drawerSidebarPaperRef }}>
             <HeaderSection closeSidebar={closeSidebar} />
             <Divider />
             <UserDetailsSection sidebarView={sidebarView} />


### PR DESCRIPTION
## Description

### Issue 
The sidebar is stuck in the position, where the user closed it last time.  
It was caused by making the sidebar permanently mounted which was to fix export progress not working after the sidebar close and open issue 

### Fix 
added logic to reset the scroll position when the user closes the sidebar 

## Test Plan

tested the fix locally
