### PR TITLE
missing translation key handling

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -14,6 +14,8 @@ export const setupI18n = async () => {
         // init i18next
         // for all options read: https://www.i18next.com/overview/configuration-options
         .init({
+            returnEmptyString: false,
+            fallbackLng: 'en',
             lng: getBestPossibleUserLocale(),
             interpolation: {
                 escapeValue: false, // not needed for react as it escapes by default


### PR DESCRIPTION
## Description

added fallback language and config to ignore empty strings as translation

## Test Plan

tested locally 
