### PR TITLE
Simplify export Flows

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -300,7 +300,7 @@
     "EXPORT_DATA": "Export data",
     "SELECT_FOLDER": "Select folder",
     "DESTINATION": "Destination",
-    "EXPORT_FILE_COUNT": "File count",
+    "FILE_COUNT": "File count",
     "START": "Start",
     "EXPORT_IN_PROGRESS": "Export in progress...",
     "PAUSE": "Pause",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -300,7 +300,7 @@
     "EXPORT_DATA": "Export data",
     "SELECT_FOLDER": "Select folder",
     "DESTINATION": "Destination",
-    "EXPORT_SIZE": "Export size",
+    "EXPORT_FILE_COUNT": "File count",
     "START": "Start",
     "EXPORT_IN_PROGRESS": "Export in progress...",
     "PAUSE": "Pause",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -300,7 +300,7 @@
     "EXPORT_DATA": "Export data",
     "SELECT_FOLDER": "Select folder",
     "DESTINATION": "Destination",
-    "FILE_COUNT": "File count",
+    "TOTAL_FILE_COUNT": "Total file count",
     "START": "Start",
     "EXPORT_IN_PROGRESS": "Export in progress...",
     "PAUSE": "Pause",
@@ -568,5 +568,7 @@
         "WEEK": "after a week",
         "MONTH": "after a month",
         "YEAR": "after a year"
-    }
+    },
+    "STOP_EXPORT": "Stop",
+    "EXPORT_PROGRESS": "<a>{{progress.current}} / {{progress.total}}</a> files exported"
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -298,7 +298,6 @@
     "EXPORT_DATA": "Exporter les données",
     "SELECT_FOLDER": "Sélectionner un dossier",
     "DESTINATION": "Destination",
-    "FILE_COUNT": "",
     "START": "Démarrer",
     "EXPORT_IN_PROGRESS": "Export en cours...",
     "PAUSE": "Pause",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -298,7 +298,7 @@
     "EXPORT_DATA": "Exporter les données",
     "SELECT_FOLDER": "Sélectionner un dossier",
     "DESTINATION": "Destination",
-    "EXPORT_FILE_COUNT": "",
+    "FILE_COUNT": "",
     "START": "Démarrer",
     "EXPORT_IN_PROGRESS": "Export en cours...",
     "PAUSE": "Pause",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -298,7 +298,7 @@
     "EXPORT_DATA": "Exporter les données",
     "SELECT_FOLDER": "Sélectionner un dossier",
     "DESTINATION": "Destination",
-    "EXPORT_SIZE": "Taille d'export",
+    "EXPORT_FILE_COUNT": "",
     "START": "Démarrer",
     "EXPORT_IN_PROGRESS": "Export en cours...",
     "PAUSE": "Pause",

--- a/src/components/Container.ts
+++ b/src/components/Container.ts
@@ -27,10 +27,6 @@ export const Row = styled('div')`
     flex: 1;
 `;
 
-export const Label = styled('div')<{ width?: string }>`
-    width: ${(props) => props.width ?? '70%'};
-    color: ${(props) => props.theme.palette.text.secondary};
-`;
 export const Value = styled('div')<{ width?: string }>`
     display: flex;
     justify-content: flex-start;
@@ -76,4 +72,12 @@ export const IconButtonWithBG = styled(IconButton)(({ theme }) => ({
 
 export const HorizontalFlex = styled(Box)({
     display: 'flex',
+});
+
+export const VerticalFlex = styled(HorizontalFlex)({
+    flexDirection: 'column',
+});
+
+export const VerticallyCenteredFlex = styled(HorizontalFlex)({
+    alignItems: 'center',
 });

--- a/src/components/ExportFinished.tsx
+++ b/src/components/ExportFinished.tsx
@@ -1,10 +1,15 @@
-import { Button, DialogActions, DialogContent, Stack } from '@mui/material';
+import {
+    Button,
+    DialogActions,
+    DialogContent,
+    Stack,
+    Typography,
+} from '@mui/material';
 import React from 'react';
 import { t } from 'i18next';
 import { ExportStats } from 'types/export';
 import { formatDateTime } from 'utils/time/format';
-import { FlexWrapper, Label, Value } from './Container';
-import { ComfySpan } from './ExportInProgress';
+import { SpaceBetweenFlex } from './Container';
 
 interface Props {
     onHide: () => void;
@@ -17,30 +22,28 @@ export default function ExportFinished(props: Props) {
     return (
         <>
             <DialogContent>
-                <Stack spacing={2.5}>
-                    <FlexWrapper>
-                        <Label width="40%">{t('LAST_EXPORT_TIME')}</Label>
-                        <Value width="60%">
+                <Stack spacing={2.5} pr={2}>
+                    <SpaceBetweenFlex>
+                        <Typography color="text.secondary">
+                            {t('LAST_EXPORT_TIME')}
+                        </Typography>
+                        <Typography>
                             {formatDateTime(props.lastExportTime)}
-                        </Value>
-                    </FlexWrapper>
-                    <FlexWrapper>
-                        <Label width="40%">
+                        </Typography>
+                    </SpaceBetweenFlex>
+                    <SpaceBetweenFlex>
+                        <Typography color="text.secondary">
                             {t('SUCCESSFULLY_EXPORTED_FILES')}
-                        </Label>
-                        <Value width="60%">{props.exportStats.success}</Value>
-                    </FlexWrapper>
+                        </Typography>
+                        <Typography>{props.exportStats.success}</Typography>
+                    </SpaceBetweenFlex>
                     {props.exportStats.failed > 0 && (
-                        <FlexWrapper>
-                            <Label width="40%">
+                        <SpaceBetweenFlex>
+                            <Typography color="text.secondary">
                                 {t('FAILED_EXPORTED_FILES')}
-                            </Label>
-                            <Value width="60%">
-                                <ComfySpan>
-                                    {props.exportStats.failed}
-                                </ComfySpan>
-                            </Value>
-                        </FlexWrapper>
+                            </Typography>
+                            <Typography>{props.exportStats.failed}</Typography>
+                        </SpaceBetweenFlex>
                     )}
                 </Stack>
             </DialogContent>

--- a/src/components/ExportFinished.tsx
+++ b/src/components/ExportFinished.tsx
@@ -10,12 +10,10 @@ interface Props {
     onHide: () => void;
     lastExportTime: number;
     exportStats: ExportStats;
-    exportFiles: () => void;
-    retryFailed: () => void;
+    startExport: () => void;
 }
 
 export default function ExportFinished(props: Props) {
-    const totalFiles = props.exportStats.failed + props.exportStats.success;
     return (
         <>
             <DialogContent>
@@ -30,11 +28,7 @@ export default function ExportFinished(props: Props) {
                         <Label width="40%">
                             {t('SUCCESSFULLY_EXPORTED_FILES')}
                         </Label>
-                        <Value width="60%">
-                            <ComfySpan>
-                                {props.exportStats.success} / {totalFiles}
-                            </ComfySpan>
-                        </Value>
+                        <Value width="60%">{props.exportStats.success}</Value>
                     </FlexWrapper>
                     {props.exportStats.failed > 0 && (
                         <FlexWrapper>
@@ -43,7 +37,7 @@ export default function ExportFinished(props: Props) {
                             </Label>
                             <Value width="60%">
                                 <ComfySpan>
-                                    {props.exportStats.failed} / {totalFiles}
+                                    {props.exportStats.failed}
                                 </ComfySpan>
                             </Value>
                         </FlexWrapper>
@@ -51,23 +45,14 @@ export default function ExportFinished(props: Props) {
                 </Stack>
             </DialogContent>
             <DialogActions>
-                {props.exportStats.failed !== 0 ? (
-                    <Button
-                        size="large"
-                        color="accent"
-                        onClick={props.retryFailed}>
-                        {t('RETRY_EXPORT')}
-                    </Button>
-                ) : (
-                    <Button
-                        size="large"
-                        color="primary"
-                        onClick={props.exportFiles}>
-                        {t('EXPORT_AGAIN')}
-                    </Button>
-                )}
                 <Button color="secondary" size="large" onClick={props.onHide}>
                     {t('CLOSE')}
+                </Button>
+                <Button
+                    size="large"
+                    color="primary"
+                    onClick={props.startExport}>
+                    {t('EXPORT_AGAIN')}
                 </Button>
             </DialogActions>
         </>

--- a/src/components/ExportInProgress.tsx
+++ b/src/components/ExportInProgress.tsx
@@ -11,8 +11,10 @@ import { ExportStage } from 'constants/export';
 import VerticallyCentered, { FlexWrapper } from './Container';
 import { ProgressBar } from 'react-bootstrap';
 import { t } from 'i18next';
+import { Trans } from 'react-i18next';
 
 export const ComfySpan = styled('span')`
+    padding: 0 0.5rem;
     word-spacing: 1rem;
     color: #ddd;
 `;
@@ -20,9 +22,8 @@ export const ComfySpan = styled('span')`
 interface Props {
     exportStage: ExportStage;
     exportProgress: ExportProgress;
-    resumeExport: () => void;
-    cancelExport: () => void;
-    pauseExport: () => void;
+    stopExport: () => void;
+    closeExportDialog: () => void;
 }
 
 export default function ExportInProgress(props: Props) {
@@ -31,17 +32,15 @@ export default function ExportInProgress(props: Props) {
             <DialogContent>
                 <VerticallyCentered>
                     <Box mb={1.5}>
-                        <ComfySpan>
-                            {' '}
-                            {props.exportProgress.current} /{' '}
-                            {props.exportProgress.total}{' '}
-                        </ComfySpan>{' '}
-                        <span>
-                            {' '}
-                            files exported{' '}
-                            {props.exportStage === ExportStage.PAUSED &&
-                                `(paused)`}
-                        </span>
+                        <Trans
+                            i18nKey={'EXPORT_PROGRESS'}
+                            components={{
+                                a: <ComfySpan />,
+                            }}
+                            values={{
+                                progress: props.exportProgress,
+                            }}
+                        />
                     </Box>
                     <FlexWrapper px={1}>
                         <ProgressBar
@@ -50,35 +49,21 @@ export default function ExportInProgress(props: Props) {
                                 (props.exportProgress.current * 100) /
                                     props.exportProgress.total
                             )}
-                            animated={
-                                !(props.exportStage === ExportStage.PAUSED)
-                            }
+                            animated
                             variant="upload-progress-bar"
                         />
                     </FlexWrapper>
                 </VerticallyCentered>
             </DialogContent>
             <DialogActions>
-                {props.exportStage === ExportStage.PAUSED ? (
-                    <Button
-                        size="large"
-                        onClick={props.resumeExport}
-                        color="accent">
-                        {t('RESUME')}
-                    </Button>
-                ) : (
-                    <Button
-                        size="large"
-                        onClick={props.pauseExport}
-                        color="primary">
-                        {t('PAUSE')}
-                    </Button>
-                )}
                 <Button
+                    color="secondary"
                     size="large"
-                    onClick={props.cancelExport}
-                    color="secondary">
-                    {t('CANCEL')}
+                    onClick={props.closeExportDialog}>
+                    {t('CLOSE')}
+                </Button>
+                <Button size="large" color="danger" onClick={props.stopExport}>
+                    {t('STOP_EXPORT')}
                 </Button>
             </DialogActions>
         </>

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -117,11 +117,6 @@ export default function ExportModal(props: Props) {
         void main();
     }, [exportFolder]);
 
-    const updateTotalFileCount = async () => {
-        const userPersonalFiles = getUserPersonalFiles(await getLocalFiles());
-        setTotalFileCount(userPersonalFiles?.length ?? 0);
-    };
-
     useEffect(() => {
         if (!props.show) {
             return;
@@ -168,6 +163,18 @@ export default function ExportModal(props: Props) {
         };
         void main();
     }, [props.show]);
+
+    const updateTotalFileCount = async () => {
+        try {
+            const userPersonalFiles = getUserPersonalFiles(
+                await getLocalFiles()
+            );
+            setTotalFileCount(userPersonalFiles?.length ?? 0);
+        } catch (e) {
+            logError(e, 'updateTotalFileCount failed');
+            throw e;
+        }
+    };
 
     // =============
     // STATE UPDATERS

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -4,17 +4,18 @@ import exportService from 'services/exportService';
 import { ExportProgress, ExportStats } from 'types/export';
 import { getLocalFiles } from 'services/fileService';
 import {
+    Box,
     Button,
     Dialog,
     DialogContent,
     Divider,
-    Stack,
     styled,
     Tooltip,
+    Typography,
 } from '@mui/material';
 import { logError } from 'utils/sentry';
 import { getData, LS_KEYS, setData } from 'utils/storage/localStorage';
-import { FlexWrapper, Label, Value } from './Container';
+import { SpaceBetweenFlex, VerticallyCenteredFlex } from './Container';
 import ExportFinished from './ExportFinished';
 import ExportInit from './ExportInit';
 import ExportInProgress from './ExportInProgress';
@@ -263,14 +264,12 @@ export default function ExportModal(props: Props) {
                 {t('EXPORT_DATA')}
             </DialogTitleWithCloseButton>
             <DialogContent>
-                <Stack spacing={2}>
-                    <ExportDirectory
-                        exportFolder={exportFolder}
-                        selectExportDirectory={selectExportDirectory}
-                        exportStage={exportStage}
-                    />
-                    <TotalFileCount totalFileCount={totalFileCount} />
-                </Stack>
+                <ExportDirectory
+                    exportFolder={exportFolder}
+                    selectExportDirectory={selectExportDirectory}
+                    exportStage={exportStage}
+                />
+                <TotalFileCount totalFileCount={totalFileCount} />
             </DialogContent>
             <Divider />
             <ExportDynamicContent />
@@ -280,39 +279,43 @@ export default function ExportModal(props: Props) {
 
 function ExportDirectory({ exportFolder, selectExportDirectory, exportStage }) {
     return (
-        <FlexWrapper>
-            <Label width="30%">{t('DESTINATION')}</Label>
-            <Value width="70%">
+        <SpaceBetweenFlex minHeight={'40px'}>
+            <Typography color="text.secondary">{t('DESTINATION')}</Typography>
+            <>
                 {!exportFolder ? (
                     <Button color={'accent'} onClick={selectExportDirectory}>
                         {t('SELECT_FOLDER')}
                     </Button>
                 ) : (
-                    <>
+                    <VerticallyCenteredFlex>
                         <Tooltip title={exportFolder}>
                             <ExportFolderPathContainer>
                                 {exportFolder}
                             </ExportFolderPathContainer>
                         </Tooltip>
-                        {(exportStage === ExportStage.FINISHED ||
-                            exportStage === ExportStage.INIT) && (
+                        {exportStage === ExportStage.FINISHED ||
+                        exportStage === ExportStage.INIT ? (
                             <ExportDirectoryOption
                                 selectExportDirectory={selectExportDirectory}
                             />
+                        ) : (
+                            <Box sx={{ width: '48px' }} />
                         )}
-                    </>
+                    </VerticallyCenteredFlex>
                 )}
-            </Value>
-        </FlexWrapper>
+            </>
+        </SpaceBetweenFlex>
     );
 }
 
 function TotalFileCount({ totalFileCount }) {
     return (
-        <FlexWrapper>
-            <Label width="30%">{t('TOTAL_FILE_COUNT')} </Label>
-            <Value width="70%">{totalFileCount}</Value>
-        </FlexWrapper>
+        <SpaceBetweenFlex minHeight={'40px'} pr={2}>
+            <Typography color={'text.secondary'}>
+                {t('TOTAL_FILE_COUNT')}{' '}
+            </Typography>
+            <Typography>{totalFileCount}</Typography>
+        </SpaceBetweenFlex>
     );
 }
 

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -87,9 +87,6 @@ export default function ExportModal(props: Props) {
                 const exportInfo = await exportService.getExportRecord();
                 setExportStage(exportInfo?.stage ?? ExportStage.INIT);
                 setLastExportTime(exportInfo?.lastAttemptTimestamp);
-                setExportProgress(
-                    exportInfo?.progress ?? { current: 0, total: 0 }
-                );
                 setExportStats({
                     success: exportInfo?.exportedFiles?.length ?? 0,
                     failed: exportInfo?.failedFiles?.length ?? 0,
@@ -140,11 +137,6 @@ export default function ExportModal(props: Props) {
         await exportService.updateExportRecord({
             lastAttemptTimestamp: newTime,
         });
-    };
-
-    const updateExportProgress = async (newProgress: ExportProgress) => {
-        setExportProgress(newProgress);
-        await exportService.updateExportRecord({ progress: newProgress });
     };
 
     // ======================
@@ -198,13 +190,13 @@ export default function ExportModal(props: Props) {
 
             const exportRecord = await exportService.getExportRecord();
             const exportedFileCount = exportRecord?.exportedFiles?.length ?? 0;
-            updateExportProgress({
+            setExportProgress({
                 current: exportedFileCount,
                 total: totalFileCount,
             });
 
             const updateExportStatsWithOffset = (current: number) =>
-                updateExportProgress({
+                setExportProgress({
                     current: exportedFileCount + current,
                     total: totalFileCount,
                 });

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -117,7 +117,7 @@ export default function ExportModal(props: Props) {
         void main();
     }, [exportFolder]);
 
-    const updateExportInfo = async () => {
+    const updateTotalFileCount = async () => {
         const userPersonalFiles = getUserPersonalFiles(await getLocalFiles());
         setTotalFileCount(userPersonalFiles?.length ?? 0);
     };
@@ -127,7 +127,7 @@ export default function ExportModal(props: Props) {
             return;
         }
         const main = async () => {
-            await updateExportInfo();
+            await updateTotalFileCount();
             const user: User = getData(LS_KEYS.USER);
             if (exportStage === ExportStage.FINISHED) {
                 try {
@@ -392,7 +392,7 @@ export default function ExportModal(props: Props) {
                         selectExportDirectory={selectExportDirectory}
                         exportStage={exportStage}
                     />
-                    <ExportFileCount exportFileCount={totalFileCount} />
+                    <TotalFileCount totalFileCount={totalFileCount} />
                 </Stack>
             </DialogContent>
             <Divider />
@@ -430,11 +430,11 @@ function ExportDirectory({ exportFolder, selectExportDirectory, exportStage }) {
     );
 }
 
-function ExportFileCount({ exportFileCount }) {
+function TotalFileCount({ totalFileCount }) {
     return (
         <FlexWrapper>
-            <Label width="30%">{t('EXPORT_FILE_COUNT')} </Label>
-            <Value width="70%">{exportFileCount}</Value>
+            <Label width="30%">{t('FILE_COUNT')} </Label>
+            <Value width="70%">{totalFileCount}</Value>
         </FlexWrapper>
     );
 }

--- a/src/components/PhotoViewer/FileInfo/RenderInfoItem.tsx
+++ b/src/components/PhotoViewer/FileInfo/RenderInfoItem.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { Label, Row, Value } from 'components/Container';
-
-export const RenderInfoItem = (label: string, value: string | JSX.Element) => (
-    <Row>
-        <Label width="30%">{label}</Label>
-        <Value width="70%">{value}</Value>
-    </Row>
-);

--- a/src/components/UserNameInputDialog.tsx
+++ b/src/components/UserNameInputDialog.tsx
@@ -33,7 +33,7 @@ export default function UserNameInputDialog({
                 initialValue={uploaderName}
                 callback={handleSubmit}
                 placeholder={t('NAME_PLACEHOLDER')}
-                buttonText={t('add_photos', { count: toUploadFilesCount })}
+                buttonText={t('add_photos', { count: toUploadFilesCount ?? 0 })}
                 fieldType="text"
                 blockButton
                 secondaryButtonAction={onClose}

--- a/src/constants/export/index.ts
+++ b/src/constants/export/index.ts
@@ -15,14 +15,7 @@ export enum RecordType {
     FAILED = 'failed',
 }
 export enum ExportStage {
-    INIT,
-    INPROGRESS,
-    PAUSED,
-    FINISHED,
-}
-
-export enum ExportType {
-    NEW,
-    PENDING,
-    RETRY_FAILED,
+    INIT = 0,
+    INPROGRESS = 1,
+    FINISHED = 3,
 }

--- a/src/types/export/index.ts
+++ b/src/types/export/index.ts
@@ -13,7 +13,7 @@ export interface ExportStats {
     success: number;
 }
 
-export interface ExportRecord {
+export interface ExportRecordV1 {
     version?: number;
     stage?: ExportStage;
     lastAttemptTimestamp?: number;
@@ -22,4 +22,13 @@ export interface ExportRecord {
     exportedFiles?: string[];
     failedFiles?: string[];
     exportedCollectionPaths?: ExportedCollectionPaths;
+}
+
+export interface ExportRecord {
+    version: number;
+    stage: ExportStage;
+    lastAttemptTimestamp: number;
+    exportedFiles: string[];
+    failedFiles: string[];
+    exportedCollectionPaths: ExportedCollectionPaths;
 }

--- a/src/utils/export/index.ts
+++ b/src/utils/export/index.ts
@@ -79,7 +79,7 @@ export const getCollectionsRenamedAfterLastExport = (
     return renamedCollections;
 };
 
-export const getFilesUploadedAfterLastExport = (
+export const getUnExportedFiles = (
     allFiles: EnteFile[],
     exportRecord: ExportRecord
 ) => {

--- a/src/utils/export/index.ts
+++ b/src/utils/export/index.ts
@@ -13,20 +13,6 @@ import { formatDateTimeShort } from 'utils/time/format';
 export const getExportRecordFileUID = (file: EnteFile) =>
     `${file.id}_${file.collectionID}_${file.updationTime}`;
 
-export const getExportQueuedFiles = (
-    allFiles: EnteFile[],
-    exportRecord: ExportRecord
-) => {
-    const queuedFiles = new Set(exportRecord?.queuedFiles);
-    const unExportedFiles = allFiles.filter((file) => {
-        if (queuedFiles.has(getExportRecordFileUID(file))) {
-            return true;
-        }
-        return false;
-    });
-    return unExportedFiles;
-};
-
 export const getCollectionsCreatedAfterLastExport = (
     collections: Collection[],
     exportRecord: ExportRecord

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -578,3 +578,11 @@ export function getLatestVersionFiles(files: EnteFile[]) {
         (file) => !file.isDeleted
     );
 }
+
+export function getUserPersonalFiles(files: EnteFile[]) {
+    const user: User = getData(LS_KEYS.USER);
+    if (!user?.id) {
+        throw Error('user missing');
+    }
+    return files.filter((file) => file.ownerID === user.id);
+}


### PR DESCRIPTION
## Description

- removed export size and added total file count info
- updated layout
-  removed separately retry failed export button, same resync button will trigger export for all unexported files( including those failed during last export )
- removed pausing/resume logic, export now always resumes from the last export state automatically
- deprecated `queuedFiles` and `progress`  properties from `exportRecord`

## Test Plan

pending 
