### PR TITLE
Fix continous export bug

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -578,5 +578,6 @@
     },
     "CONTINUOUS_EXPORT": "Sync continuously",
     "TOTAL_ITEMS": "Total items",
-    "PENDING_ITEMS": "Pending items"
+    "PENDING_ITEMS": "Pending items",
+    "EXPORT_STARTING": "Export starting..."
 }

--- a/src/components/ExportInProgress.tsx
+++ b/src/components/ExportInProgress.tsx
@@ -33,7 +33,7 @@ export default function ExportInProgress(props: Props) {
             <DialogContent>
                 <VerticallyCentered>
                     <Box mb={1.5}>
-                        {props.exportProgress.total === 0 ? (
+                        {isLoading ? (
                             t('EXPORT_STARTING')
                         ) : (
                             <Trans

--- a/src/components/ExportInProgress.tsx
+++ b/src/components/ExportInProgress.tsx
@@ -27,13 +27,7 @@ interface Props {
 }
 
 export default function ExportInProgress(props: Props) {
-    const progress =
-        props.exportProgress.total > 0
-            ? Math.round(
-                  (props.exportProgress.current * 100) /
-                      props.exportProgress.total
-              )
-            : 100;
+    const isLoading = props.exportProgress.total === 0;
     return (
         <>
             <DialogContent>
@@ -56,7 +50,14 @@ export default function ExportInProgress(props: Props) {
                     <FlexWrapper px={1}>
                         <ProgressBar
                             style={{ width: '100%' }}
-                            now={progress}
+                            now={
+                                isLoading
+                                    ? 100
+                                    : Math.round(
+                                          (props.exportProgress.current * 100) /
+                                              props.exportProgress.total
+                                      )
+                            }
                             animated
                             variant="upload-progress-bar"
                         />

--- a/src/components/ExportInProgress.tsx
+++ b/src/components/ExportInProgress.tsx
@@ -27,28 +27,36 @@ interface Props {
 }
 
 export default function ExportInProgress(props: Props) {
+    const progress =
+        props.exportProgress.total > 0
+            ? Math.round(
+                  (props.exportProgress.current * 100) /
+                      props.exportProgress.total
+              )
+            : 100;
     return (
         <>
             <DialogContent>
                 <VerticallyCentered>
                     <Box mb={1.5}>
-                        <Trans
-                            i18nKey={'EXPORT_PROGRESS'}
-                            components={{
-                                a: <ComfySpan />,
-                            }}
-                            values={{
-                                progress: props.exportProgress,
-                            }}
-                        />
+                        {props.exportProgress.total === 0 ? (
+                            t('EXPORT_STARTING')
+                        ) : (
+                            <Trans
+                                i18nKey={'EXPORT_PROGRESS'}
+                                components={{
+                                    a: <ComfySpan />,
+                                }}
+                                values={{
+                                    progress: props.exportProgress,
+                                }}
+                            />
+                        )}
                     </Box>
                     <FlexWrapper px={1}>
                         <ProgressBar
                             style={{ width: '100%' }}
-                            now={Math.round(
-                                (props.exportProgress.current * 100) /
-                                    props.exportProgress.total
-                            )}
+                            now={progress}
                             animated
                             variant="upload-progress-bar"
                         />

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -209,6 +209,7 @@ export default function ExportModal(props: Props) {
     const startExport = async () => {
         try {
             await preExportRun();
+            setExportProgress({ current: 0, total: 0 });
             await exportService.exportFiles(setExportProgress);
             await postExportRun();
         } catch (e) {

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -29,6 +29,7 @@ import { AppContext } from 'pages/_app';
 import { getExportDirectoryDoesNotExistMessage } from 'utils/ui';
 import { t } from 'i18next';
 import LinkButton from './pages/gallery/LinkButton';
+import { CustomError } from 'utils/error';
 
 const ExportFolderPathContainer = styled(LinkButton)`
     width: 262px;
@@ -163,7 +164,7 @@ export default function ExportModal(props: Props) {
             appContext.setDialogMessage(
                 getExportDirectoryDoesNotExistMessage()
             );
-            return;
+            throw Error(CustomError.EXPORT_FOLDER_DOES_NOT_EXIST);
         }
         await updateExportStage(ExportStage.INPROGRESS);
     };
@@ -211,7 +212,9 @@ export default function ExportModal(props: Props) {
             await exportService.exportFiles(setExportProgress);
             await postExportRun();
         } catch (e) {
-            logError(e, 'startExport failed');
+            if (e.message !== CustomError.EXPORT_FOLDER_DOES_NOT_EXIST) {
+                logError(e, 'startExport failed');
+            }
         }
     };
 

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -108,6 +108,7 @@ class ExportService {
                     if (this.exportInProgress) {
                         addLogLine('export in progress, scheduling re-run');
                         reRunNeeded.current = true;
+                        return;
                     }
                     await startExport();
                     if (reRunNeeded.current) {

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -335,20 +335,8 @@ class ExportService {
                     exportRecord.exportedFiles = [];
                 }
                 exportRecord.exportedFiles.push(fileUID);
-                exportRecord.failedFiles &&
-                    (exportRecord.failedFiles = exportRecord.failedFiles.filter(
-                        (FailedFileUID) => FailedFileUID !== fileUID
-                    ));
-            } else {
-                if (!exportRecord.failedFiles) {
-                    exportRecord.failedFiles = [];
-                }
-                if (!exportRecord.failedFiles.find((x) => x === fileUID)) {
-                    exportRecord.failedFiles.push(fileUID);
-                }
             }
             exportRecord.exportedFiles = dedupe(exportRecord.exportedFiles);
-            exportRecord.failedFiles = dedupe(exportRecord.failedFiles);
             await this.updateExportRecord(exportRecord, folder);
         } catch (e) {
             logError(e, 'addFileExportedRecord failed');
@@ -701,6 +689,9 @@ class ExportService {
         }
         if (exportRecord?.progress) {
             exportRecord.progress = undefined;
+        }
+        if (exportRecord?.failedFiles) {
+            exportRecord.failedFiles = undefined;
         }
         await this.updateExportRecord(exportRecord);
     }

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -406,20 +406,16 @@ class ExportService {
                 folder = getData(LS_KEYS.EXPORT)?.folder;
             }
             if (!folder) {
-                throw Error(CustomError.NO_EXPORT_FOLDER_SELECTED);
+                return null;
             }
             const exportFolderExists = this.exists(folder);
             if (!exportFolderExists) {
-                throw Error(CustomError.EXPORT_FOLDER_DOES_NOT_EXIST);
+                return null;
             }
             const recordFile = await this.electronAPIs.getExportRecord(
                 `${folder}/${EXPORT_RECORD_FILE_NAME}`
             );
-            if (recordFile) {
-                return JSON.parse(recordFile);
-            } else {
-                return {} as ExportRecord;
-            }
+            return JSON.parse(recordFile);
         } catch (e) {
             logError(e, 'export Record JSON parsing failed ');
             throw e;

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -273,8 +273,8 @@ class ExportService {
             }
             this.stopExport = false;
             this.electronAPIs.sendNotification(t('EXPORT_NOTIFICATION.START'));
-
-            for (const [index, file] of files.entries()) {
+            let success = 0;
+            for (const file of files) {
                 if (this.stopExport) {
                     break;
                 }
@@ -296,7 +296,8 @@ class ExportService {
                         file,
                         RecordType.SUCCESS
                     );
-                    updateProgress({ current: index + 1, total: files.length });
+                    success++;
+                    updateProgress({ current: success, total: files.length });
                 } catch (e) {
                     logError(e, 'export failed for a file');
                     if (

--- a/src/types/export/index.ts
+++ b/src/types/export/index.ts
@@ -26,7 +26,6 @@ export interface ExportRecord {
     stage: ExportStage;
     lastAttemptTimestamp: number;
     exportedFiles: string[];
-    failedFiles: string[];
     exportedCollectionPaths: ExportedCollectionPaths;
 }
 

--- a/src/utils/export/index.ts
+++ b/src/utils/export/index.ts
@@ -93,20 +93,6 @@ export const getExportedFiles = (
     return exportedFiles;
 };
 
-export const getExportFailedFiles = (
-    allFiles: EnteFile[],
-    exportRecord: ExportRecord
-) => {
-    const failedFiles = new Set(exportRecord?.failedFiles);
-    const filesToExport = allFiles.filter((file) => {
-        if (failedFiles.has(getExportRecordFileUID(file))) {
-            return true;
-        }
-        return false;
-    });
-    return filesToExport;
-};
-
 export const dedupe = (files: string[]) => {
     const fileSet = new Set(files);
     return Array.from(fileSet);


### PR DESCRIPTION
## Description

- fix new updates getting missed when export is already in progress
- better handle no folder selected state.
- removed failed files state  from export record JSON too 
- fixed progress bar increasing for failed files too

added "export starting state" loading message 
<img width="622" alt="image" src="https://user-images.githubusercontent.com/46242073/228241915-711ffe13-1674-4a54-baf0-a018e2caf9d2.png">

## Test Plan

- tested by uploading new files when export is in progress and verified that they are queued for export after the current export finishes
- tested starting export / running continuous export with no export folder selected.
- tested normal export
- tested progress bar fix by explicitly failing files