### PR TITLE
fix: typo for "No memory"

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -207,7 +207,7 @@
         "THING": "Content",
         "FILE_CAPTION": "Description"
     },
-    "photos_count_zero": "No memory",
+    "photos_count_zero": "No memories",
     "photos_count_one": "1 memory",
     "photos_count_other": "{{count}} memories",
     "TERMS_AND_CONDITIONS": "I agree to the <a>terms</a> and <b>privacy policy</b>",


### PR DESCRIPTION
## Description
Fixes a typo for the "photos_count_zero" english translation. It used to be "No memory", but it has been corrected to "No memories".

## Test Plan
Check `/gallery` without any memories in your account and open the sidebar. The text in the bottom right of the storage indicator should be "No memories".