### PR TITLE
update file type detection error handling 

### DIFF
--- a/src/constants/upload/index.ts
+++ b/src/constants/upload/index.ts
@@ -1,18 +1,20 @@
 import { ENCRYPTION_CHUNK_SIZE } from 'constants/crypto';
 import { FILE_TYPE } from 'constants/file';
 import {
+    FileTypeInfo,
     ImportSuggestion,
     Location,
     ParsedExtractedMetadata,
 } from 'types/upload';
 
 // list of format that were missed by type-detection for some files.
-export const FILE_TYPE_LIB_MISSED_FORMATS = [
+export const FILE_TYPE_LIB_MISSED_FORMATS: FileTypeInfo[] = [
     { fileType: FILE_TYPE.IMAGE, exactType: 'jpeg', mimeType: 'image/jpeg' },
     { fileType: FILE_TYPE.IMAGE, exactType: 'jpg', mimeType: 'image/jpeg' },
     { fileType: FILE_TYPE.VIDEO, exactType: 'webm', mimeType: 'video/webm' },
     { fileType: FILE_TYPE.VIDEO, exactType: 'mod', mimeType: 'video/mpeg' },
     { fileType: FILE_TYPE.VIDEO, exactType: 'mp4', mimeType: 'video/mp4' },
+    { fileType: FILE_TYPE.IMAGE, exactType: 'gif', mimeType: 'image/gif' },
 ];
 
 export const KNOWN_NON_MEDIA_FORMATS = ['xmp', 'html', 'txt'];

--- a/src/services/typeDetectionService.ts
+++ b/src/services/typeDetectionService.ts
@@ -50,11 +50,15 @@ export async function getFileType(
             mimeType: typeResult.mime,
         };
     } catch (e) {
+        const fileFormat = getFileExtension(receivedFile.name);
+        const fileSize = getFileSize(receivedFile);
+        logError(e, 'type detection failed', {
+            fileFormat,
+            fileSize: convertBytesToHumanReadable(fileSize),
+        });
         if (e.message === CustomError.UNSUPPORTED_FILE_FORMAT) {
             throw e;
         }
-        const fileFormat = getFileExtension(receivedFile.name);
-        const fileSize = getFileSize(receivedFile);
         const formatMissedByTypeDetection = FILE_TYPE_LIB_MISSED_FORMATS.find(
             (a) => a.exactType === fileFormat
         );
@@ -64,10 +68,6 @@ export async function getFileType(
         if (KNOWN_NON_MEDIA_FORMATS.includes(fileFormat)) {
             throw Error(CustomError.UNSUPPORTED_FILE_FORMAT);
         }
-        logError(e, 'type detection failed', {
-            fileFormat,
-            fileSize: convertBytesToHumanReadable(fileSize),
-        });
         throw Error(CustomError.TYPE_DETECTION_FAILED(fileFormat));
     }
 }

--- a/src/services/typeDetectionService.ts
+++ b/src/services/typeDetectionService.ts
@@ -50,15 +50,10 @@ export async function getFileType(
             mimeType: typeResult.mime,
         };
     } catch (e) {
-        const fileFormat = getFileExtension(receivedFile.name);
-        const fileSize = getFileSize(receivedFile);
-        logError(e, 'type detection failed', {
-            fileFormat,
-            fileSize: convertBytesToHumanReadable(fileSize),
-        });
         if (e.message === CustomError.UNSUPPORTED_FILE_FORMAT) {
             throw e;
         }
+        const fileFormat = getFileExtension(receivedFile.name);
         const formatMissedByTypeDetection = FILE_TYPE_LIB_MISSED_FORMATS.find(
             (a) => a.exactType === fileFormat
         );
@@ -68,6 +63,11 @@ export async function getFileType(
         if (KNOWN_NON_MEDIA_FORMATS.includes(fileFormat)) {
             throw Error(CustomError.UNSUPPORTED_FILE_FORMAT);
         }
+        const fileSize = getFileSize(receivedFile);
+        logError(e, 'type detection failed', {
+            fileFormat,
+            fileSize: convertBytesToHumanReadable(fileSize),
+        });
         throw Error(CustomError.TYPE_DETECTION_FAILED(fileFormat));
     }
 }

--- a/src/services/typeDetectionService.ts
+++ b/src/services/typeDetectionService.ts
@@ -54,19 +54,23 @@ export async function getFileType(
             throw e;
         }
         const fileFormat = getFileExtension(receivedFile.name);
+        const fileSize = convertBytesToHumanReadable(getFileSize(receivedFile));
         const formatMissedByTypeDetection = FILE_TYPE_LIB_MISSED_FORMATS.find(
             (a) => a.exactType === fileFormat
         );
         if (formatMissedByTypeDetection) {
+            logError(Error(), 'format missed by type detection', {
+                fileFormat,
+                fileSize,
+            });
             return formatMissedByTypeDetection;
         }
         if (KNOWN_NON_MEDIA_FORMATS.includes(fileFormat)) {
             throw Error(CustomError.UNSUPPORTED_FILE_FORMAT);
         }
-        const fileSize = getFileSize(receivedFile);
         logError(e, 'type detection failed', {
             fileFormat,
-            fileSize: convertBytesToHumanReadable(fileSize),
+            fileSize,
         });
         throw Error(CustomError.TYPE_DETECTION_FAILED(fileFormat));
     }

--- a/src/services/typeDetectionService.ts
+++ b/src/services/typeDetectionService.ts
@@ -9,6 +9,8 @@ import { getFileExtension } from 'utils/file';
 import { logError } from 'utils/sentry';
 import { getUint8ArrayView } from './readerService';
 import FileType, { FileTypeResult } from 'file-type';
+import { getFileSize } from './upload/fileService';
+import { convertBytesToHumanReadable } from 'utils/file/size';
 
 const TYPE_VIDEO = 'video';
 const TYPE_IMAGE = 'image';
@@ -52,6 +54,7 @@ export async function getFileType(
             throw e;
         }
         const fileFormat = getFileExtension(receivedFile.name);
+        const fileSize = getFileSize(receivedFile);
         const formatMissedByTypeDetection = FILE_TYPE_LIB_MISSED_FORMATS.find(
             (a) => a.exactType === fileFormat
         );
@@ -63,6 +66,7 @@ export async function getFileType(
         }
         logError(e, 'type detection failed', {
             fileFormat,
+            fileSize: convertBytesToHumanReadable(fileSize),
         });
         throw Error(CustomError.TYPE_DETECTION_FAILED(fileFormat));
     }

--- a/src/services/upload/uploader.ts
+++ b/src/services/upload/uploader.ts
@@ -42,8 +42,9 @@ export default async function uploader(
     UIService.setFileProgress(localID, 0);
     await sleep(0);
     let fileTypeInfo: FileTypeInfo;
+    let fileSize: number;
     try {
-        const fileSize = UploadService.getAssetSize(uploadAsset);
+        fileSize = UploadService.getAssetSize(uploadAsset);
         if (fileSize >= MAX_FILE_SIZE_SUPPORTED) {
             return { fileUploadResult: UPLOAD_RESULT.TOO_LARGE };
         }
@@ -173,6 +174,7 @@ export default async function uploader(
         ) {
             logError(e, 'file upload failed', {
                 fileFormat: fileTypeInfo?.exactType,
+                fileSize: convertBytesToHumanReadable(fileSize),
             });
         }
         const error = handleUploadError(e);


### PR DESCRIPTION
## Description

sentry reported some gif failing type detection. 
https://sentry.ente.io/organizations/ente/issues/1195/?project=2&referrer=webhooks_plugin

Added gif to missed file format list to be uploaded even on type detection failure

Also, added fileSize info to the error logs, for extra debugging info if this happens again 

## Test Plan
- tested change by intentionally breaking gif type detection and verifying that was uploaded properly
- ran sample dataset upload 

