### PR TITLE
fix emotion migration issue

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,6 +23,27 @@ const IS_SENTRY_ENABLED = getIsSentryEnabled();
 module.exports = (phase) =>
     withSentryConfig(
         withBundleAnalyzer({
+            compiler: {
+                emotion: {
+                    importMap: {
+                        '@mui/material': {
+                            styled: {
+                                canonicalImport: ['@emotion/styled', 'default'],
+                                styledBaseImport: ['@mui/material', 'styled'],
+                            },
+                        },
+                        '@mui/material/styles': {
+                            styled: {
+                                canonicalImport: ['@emotion/styled', 'default'],
+                                styledBaseImport: [
+                                    '@mui/material/styles',
+                                    'styled',
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
             transpilePackages: [
                 '@mui/material',
                 '@mui/system',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
         "jsxImportSource": "@emotion/react",
         "incremental": true
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"],
     "exclude": ["node_modules", "out", ".next", "thirdparty"]
 }


### PR DESCRIPTION
## Description

The check icon was not shown on the hover on Preview Card. 

Caused by MUI emotion migration, Nested component references were not properly handled by MUI styled util

Fixed it by using the  `importMap` config provided by the MUI team to fix it https://github.com/mui/material-ui/issues/27380#issuecomment-928973157

## Test Plan

tested locally, the issue is fixed 
