### PR TITLE
Fix ffmpeg related issue

### DIFF
--- a/src/services/ffmpeg/ffmpegService.ts
+++ b/src/services/ffmpeg/ffmpegService.ts
@@ -14,7 +14,7 @@ export async function generateVideoThumbnail(
     try {
         let seekTime = 1.0;
         const ffmpegClient = await ffmpegFactory.getFFmpegClient();
-        while (seekTime > 0) {
+        while (seekTime >= 0) {
             try {
                 return await ffmpegClient.run(
                     [
@@ -22,7 +22,7 @@ export async function generateVideoThumbnail(
                         '-i',
                         INPUT_PATH_PLACEHOLDER,
                         '-ss',
-                        `00:00:0${seekTime.toFixed(3)}`,
+                        `00:00:0${seekTime}`,
                         '-vframes',
                         '1',
                         '-vf',
@@ -33,11 +33,11 @@ export async function generateVideoThumbnail(
                     'thumb.jpeg'
                 );
             } catch (e) {
-                if (seekTime <= 0) {
+                if (seekTime === 0) {
                     throw e;
                 }
             }
-            seekTime = Number((seekTime / 10).toFixed(3));
+            seekTime--;
         }
     } catch (e) {
         logError(e, 'ffmpeg generateVideoThumbnail failed');

--- a/src/services/ffmpeg/ffmpegService.ts
+++ b/src/services/ffmpeg/ffmpegService.ts
@@ -12,7 +12,7 @@ export async function generateVideoThumbnail(
     file: File | ElectronFile
 ): Promise<File | ElectronFile> {
     try {
-        let seekTime = 1.0;
+        let seekTime = 1;
         const ffmpegClient = await ffmpegFactory.getFFmpegClient();
         while (seekTime >= 0) {
             try {

--- a/src/services/upload/thumbnailService.ts
+++ b/src/services/upload/thumbnailService.ts
@@ -171,7 +171,7 @@ async function generateVideoThumbnail(
         addLogLine(
             `ffmpeg thumbnail successfully generated ${getFileNameSize(file)}`
         );
-        return getUint8ArrayView(thumbnail);
+        return await getUint8ArrayView(thumbnail);
     } catch (e) {
         addLogLine(
             `ffmpeg thumbnail generated failed  ${getFileNameSize(

--- a/src/utils/comlink/ComlinkCryptoWorker.ts
+++ b/src/utils/comlink/ComlinkCryptoWorker.ts
@@ -3,12 +3,12 @@ import { DedicatedCryptoWorker } from 'worker/crypto.worker';
 import { ComlinkWorker } from './comlinkWorker';
 
 class ComlinkCryptoWorker {
-    private comlinkWorkerInstance: Remote<DedicatedCryptoWorker>;
+    private comlinkWorkerInstance: Promise<Remote<DedicatedCryptoWorker>>;
 
     async getInstance() {
         if (!this.comlinkWorkerInstance) {
             const comlinkWorker = getDedicatedCryptoWorker();
-            this.comlinkWorkerInstance = await comlinkWorker.remote;
+            this.comlinkWorkerInstance = comlinkWorker.remote;
         }
         return this.comlinkWorkerInstance;
     }

--- a/src/utils/comlink/ComlinkFFmpegWorker.ts
+++ b/src/utils/comlink/ComlinkFFmpegWorker.ts
@@ -3,12 +3,12 @@ import { DedicatedFFmpegWorker } from 'worker/ffmpeg.worker';
 import { ComlinkWorker } from './comlinkWorker';
 
 class ComlinkFFmpegWorker {
-    private comlinkWorkerInstance: Remote<DedicatedFFmpegWorker>;
+    private comlinkWorkerInstance: Promise<Remote<DedicatedFFmpegWorker>>;
 
     async getInstance() {
         if (!this.comlinkWorkerInstance) {
             const comlinkWorker = getDedicatedFFmpegWorker();
-            this.comlinkWorkerInstance = await comlinkWorker.remote;
+            this.comlinkWorkerInstance = comlinkWorker.remote;
         }
         return this.comlinkWorkerInstance;
     }


### PR DESCRIPTION
## Description

- fixed race condition in getInstance call causing multiple FFmpeg workers to be generated leading to tab crash
- changed thumbnail generation timestamps attempts to 1st video sec and 0th video second.

## Test Plan
- tested the changes 
- ran sample dataset upload test
