### PR TITLE
Add number formatting

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -53,14 +53,14 @@
     "ADD_PHOTOS": "Add photos",
     "ADD_MORE_PHOTOS": "Add more photos",
     "add_photos_one": "Add 1 Photo",
-    "add_photos_other": "Add {{count}} Photos",
+    "add_photos_other": "Add {{count, number}} Photos",
     "SELECT_PHOTOS": "Select photos",
     "FILE_UPLOAD": "File Upload",
     "UPLOAD_STAGE_MESSAGE": {
         "0": "Preparing to upload",
         "1": "Reading google metadata files",
-        "2": "{{uploadCounter.finished}} / {{uploadCounter.total}} files metadata extracted",
-        "3": "{{uploadCounter.finished}} / {{uploadCounter.total}} files backed up",
+        "2": "{{uploadCounter.finished, number}} / {{uploadCounter.total, number}} files metadata extracted",
+        "3": "{{uploadCounter.finished, number}} / {{uploadCounter.total, number}} files backed up",
         "4": "Cancelling remaining uploads",
         "5": "Backup complete"
     },
@@ -208,7 +208,7 @@
     },
     "photos_count_zero": "No memories",
     "photos_count_one": "1 memory",
-    "photos_count_other": "{{count}} memories",
+    "photos_count_other": "{{count, number}} memories",
     "TERMS_AND_CONDITIONS": "I agree to the <a>terms</a> and <b>privacy policy</b>",
     "ADD_TO_COLLECTION": "Add to album",
     "SELECTED": "selected",
@@ -350,7 +350,7 @@
     "PUBLIC_COLLECT": "Allow adding photos",
     "LINK_DEVICE_LIMIT": "Device limit",
     "LINK_EXPIRY": "Link expiry",
-    "LINK_EXPIRY_NEVER": "Never",
+    "NEVER": "Never",
     "DISABLE_FILE_DOWNLOAD": "Disable download",
     "DISABLE_FILE_DOWNLOAD_MESSAGE": "<p>Are you sure that you want to disable the download button for files?</p><p>Viewers can still take screenshots or save a copy of your photos using external tools.</p>",
     "MALICIOUS_CONTENT": "Contains malicious content",
@@ -378,7 +378,7 @@
     "STOP_UPLOADS_HEADER": "Stop uploads?",
     "YES_STOP_UPLOADS": "Yes, stop uploads",
     "albums_one": "1 Album",
-    "albums_other": "{{count}} Albums",
+    "albums_other": "{{count, number}} Albums",
     "ALL_ALBUMS": "All Albums",
     "ALBUMS": "Albums",
     "ENTER_TWO_FACTOR_OTP": "Enter the 6-digit code from your authenticator app.",
@@ -509,5 +509,6 @@
     "CONFIRM_DELETE_ACCOUNT": "Confirm Account Deletion",
     "FEEDBACK_REQUIRED": "Kindly help us with this information",
     "FEEDBACK_REQUIRED_FOUND_ANOTHER_SERVICE": "What does the other service do better?",
-    "RECOVER_TWO_FACTOR": "Recover two-factor"
+    "RECOVER_TWO_FACTOR": "Recover two-factor",
+    "at": "at"
 }

--- a/src/components/Collections/CollectionShare/publicShare/manage/linkExpiry.tsx
+++ b/src/components/Collections/CollectionShare/publicShare/manage/linkExpiry.tsx
@@ -64,7 +64,7 @@ export function ManageLinkExpiry({
                 subText={
                     publicShareProp?.validTill
                         ? formatDateTime(publicShareProp?.validTill / 1000)
-                        : t('LINK_EXPIRY_NEVER')
+                        : t('NEVER')
                 }>
                 {t('LINK_EXPIRY')}
             </EnteMenuItem>

--- a/src/components/DialogBox/base.tsx
+++ b/src/components/DialogBox/base.tsx
@@ -33,7 +33,7 @@ const DialogBoxBase = styled(Dialog)(({ theme }) => ({
         flexWrap: 'wrap-reverse',
     },
     '& .MuiButton-root': {
-        margin: theme.spacing(0.5, 0),
+        margin: `${theme.spacing(0.5, 0)} !important`,
     },
 }));
 

--- a/src/components/ExportFinished.tsx
+++ b/src/components/ExportFinished.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { t } from 'i18next';
 import { formatDateTime } from 'utils/time/format';
 import { SpaceBetweenFlex } from './Container';
+import { formatNumber } from 'utils/number/format';
 
 interface Props {
     pendingFileCount: number;
@@ -26,14 +27,18 @@ export default function ExportFinished(props: Props) {
                         <Typography color={'text.secondary'}>
                             {t('PENDING_ITEMS')}
                         </Typography>
-                        <Typography>{props.pendingFileCount}</Typography>
+                        <Typography>
+                            {formatNumber(props.pendingFileCount)}
+                        </Typography>
                     </SpaceBetweenFlex>
                     <SpaceBetweenFlex minHeight={'48px'}>
                         <Typography color="text.secondary">
                             {t('LAST_EXPORT_TIME')}
                         </Typography>
                         <Typography>
-                            {formatDateTime(props.lastExportTime)}
+                            {props.lastExportTime
+                                ? formatDateTime(props.lastExportTime)
+                                : t('NEVER')}
                         </Typography>
                     </SpaceBetweenFlex>
                 </Stack>

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -35,6 +35,7 @@ import { getExportDirectoryDoesNotExistMessage } from 'utils/ui';
 import { t } from 'i18next';
 import LinkButton from './pages/gallery/LinkButton';
 import { CustomError } from 'utils/error';
+import { formatNumber } from 'utils/number/format';
 
 const ExportFolderPathContainer = styled(LinkButton)`
     width: 262px;
@@ -257,7 +258,7 @@ export default function ExportModal(props: Props) {
                         {t('TOTAL_ITEMS')}
                     </Typography>
                     <Typography color="text.secondary">
-                        {fileExportStats.totalCount}
+                        {formatNumber(fileExportStats.totalCount)}
                     </Typography>
                 </SpaceBetweenFlex>
             </DialogContent>

--- a/src/components/Sidebar/ShortcutButton.tsx
+++ b/src/components/Sidebar/ShortcutButton.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { Box, ButtonProps } from '@mui/material';
 import SidebarButton from './Button';
 import { DotSeparator } from './styledComponents';
+import { formatNumber } from 'utils/number/format';
 
 type Iprops = ButtonProps<
     'button',
@@ -23,7 +24,7 @@ const ShortcutButton: FC<ButtonProps<'button', Iprops>> = ({
 
             <Box sx={{ color: 'text.secondary' }}>
                 <DotSeparator />
-                {count}
+                {formatNumber(count)}
             </Box>
         </SidebarButton>
     );

--- a/src/components/pages/dedupe/SelectedFileOptions.tsx
+++ b/src/components/pages/dedupe/SelectedFileOptions.tsx
@@ -9,6 +9,7 @@ import BackButton from '@mui/icons-material/ArrowBackOutlined';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { getTrashFilesMessage } from 'utils/ui';
 import { t } from 'i18next';
+import { formatNumber } from 'utils/number/format';
 
 const VerticalLine = styled('div')`
     position: absolute;
@@ -56,7 +57,7 @@ export default function DeduplicateOptions({
                     </IconButton>
                 )}
                 <Box ml={1.5}>
-                    {count} {t('SELECTED')}
+                    {formatNumber(count)} {t('SELECTED')}
                 </Box>
             </FluidContainer>
             <input

--- a/src/components/pages/gallery/SelectedFileOptions.tsx
+++ b/src/components/pages/gallery/SelectedFileOptions.tsx
@@ -23,6 +23,7 @@ import MoveIcon from '@mui/icons-material/ArrowForward';
 import RemoveIcon from '@mui/icons-material/RemoveCircleOutline';
 import { getTrashFilesMessage } from 'utils/ui';
 import { t } from 'i18next';
+import { formatNumber } from 'utils/number/format';
 
 interface Props {
     addToCollectionHelper: (collection: Collection) => void;
@@ -144,8 +145,9 @@ const SelectedFileOptions = ({
                     <CloseIcon />
                 </IconButton>
                 <Box ml={1.5}>
-                    {count} {t('SELECTED')}{' '}
-                    {ownCount !== count && `(${ownCount} ${t('YOURS')})`}
+                    {formatNumber(count)} {t('SELECTED')}{' '}
+                    {ownCount !== count &&
+                        `(${formatNumber(ownCount)} ${t('YOURS')})`}
                 </Box>
             </FluidContainer>
             <Stack spacing={2} direction="row" mr={2}>

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -117,7 +117,7 @@ export function getDeviceLimitOptions() {
 }
 
 export const shareExpiryOptions = () => [
-    { label: t('LINK_EXPIRY_NEVER'), value: () => 0 },
+    { label: t('NEVER'), value: () => 0 },
     {
         label: t('AFTER_TIME.HOUR'),
         value: () => getUnixTimeInMicroSecondsWithDelta({ hours: 1 }),

--- a/src/utils/number/format.ts
+++ b/src/utils/number/format.ts
@@ -1,0 +1,5 @@
+import i18n from 'i18next';
+
+export function formatNumber(value: number): string {
+    return new Intl.NumberFormat(i18n.language).format(value);
+}

--- a/src/utils/time/format.ts
+++ b/src/utils/time/format.ts
@@ -1,4 +1,4 @@
-import i18n from 'i18next';
+import i18n, { t } from 'i18next';
 
 export function formatDateFull(date: number | Date) {
     const dateTimeFormat1 = new Intl.DateTimeFormat(i18n.language, {
@@ -55,11 +55,11 @@ export function formatTime(date: number | Date) {
 }
 
 export function formatDateTimeFull(dateTime: number | Date): string {
-    return [formatDateFull(dateTime), 'at', formatTime(dateTime)].join(' ');
+    return [formatDateFull(dateTime), t('at'), formatTime(dateTime)].join(' ');
 }
 
 export function formatDateTime(dateTime: number | Date): string {
-    return [formatDate(dateTime), 'at', formatTime(dateTime)].join(' ');
+    return [formatDate(dateTime), t('at'), formatTime(dateTime)].join(' ');
 }
 
 export function formatDateRelative(date: number) {


### PR DESCRIPTION
## Description

Add Number formatting, to display numbers with language-specific separators.

<img width="277" alt="image" src="https://user-images.githubusercontent.com/46242073/230720513-82d633b9-a2b3-480a-84b5-fc7fd69f459d.png">
 

## Test Plan

tested locally 
