### PR TITLE
fix Upload issues

### DIFF
--- a/src/components/Upload/UploadProgress/index.tsx
+++ b/src/components/Upload/UploadProgress/index.tsx
@@ -13,7 +13,6 @@ import {
     InProgressUpload,
 } from 'types/upload/ui';
 import UploadProgressContext from 'contexts/uploadProgress';
-import watchFolderService from 'services/watchFolder/watchFolderService';
 
 interface Props {
     open: boolean;
@@ -42,17 +41,13 @@ export default function UploadProgress({
     ...props
 }: Props) {
     const appContext = useContext(AppContext);
-    const [expanded, setExpanded] = useState(true);
+    const [expanded, setExpanded] = useState(false);
 
-    // run watch folder minimized by default
     useEffect(() => {
-        if (
-            appContext.isFolderSyncRunning &&
-            watchFolderService.isUploadRunning()
-        ) {
+        if (open) {
             setExpanded(false);
         }
-    }, [appContext.isFolderSyncRunning]);
+    }, [open]);
 
     function confirmCancelUpload() {
         appContext.setDialogMessage({

--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -508,7 +508,6 @@ export default function Uploader(props: Props) {
             logError(err, 'failed to upload files');
             showUserFacingError(err.message);
             closeUploadProgress();
-            throw err;
         } finally {
             postUploadAction();
         }

--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -239,7 +239,7 @@ export default function Uploader(props: Props) {
                     appContext?.sharedFiles.length
                 }`
             );
-            if (uploadRunning.current) {
+            if (uploadManager.isUploadRunning()) {
                 if (watchFolderService.isUploadRunning()) {
                     addLogLine(
                         'watchFolder upload was running, pausing it to run user upload'

--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -250,6 +250,7 @@ export default function Uploader(props: Props) {
                     addLogLine(
                         'an upload is already running, rejecting new upload request'
                     );
+                    setUploadProgressView(true);
                     // no-op
                     // a user upload is already in progress
                     return;

--- a/src/services/upload/uiService.ts
+++ b/src/services/upload/uiService.ts
@@ -17,6 +17,7 @@ import uploadCancelService from './uploadCancelService';
 const REQUEST_TIMEOUT_TIME = 30 * 1000; // 30 sec;
 class UIService {
     private progressUpdater: ProgressUpdater;
+
     // UPLOAD LEVEL STATES
     private uploadStage: UPLOAD_STAGES = UPLOAD_STAGES.START;
     private filenames: Map<number, string> = new Map();

--- a/src/services/upload/uiService.ts
+++ b/src/services/upload/uiService.ts
@@ -27,14 +27,12 @@ class UIService {
     private perFileProgress: number;
     private filesUploadedCount: number;
     private totalFilesCount: number;
-    private percentComplete: number = 0;
     private inProgressUploads: InProgressUploads = new Map();
     private finishedUploads: FinishedUploads = new Map();
 
     init(progressUpdater: ProgressUpdater) {
         this.progressUpdater = progressUpdater;
         this.progressUpdater.setUploadStage(this.uploadStage);
-        this.progressUpdater.setPercentComplete(this.percentComplete);
         this.progressUpdater.setUploadFilenames(this.filenames);
         this.progressUpdater.setHasLivePhotos(this.hasLivePhoto);
         this.progressUpdater.setUploadCounter({
@@ -51,7 +49,6 @@ class UIService {
 
     reset(count = 0) {
         this.setTotalFileCount(count);
-        this.percentComplete = 0;
         this.filesUploadedCount = 0;
         this.inProgressUploads = new Map<number, number>();
         this.finishedUploads = new Map<number, UPLOAD_RESULT>();
@@ -77,11 +74,6 @@ class UIService {
         this.progressUpdater.setUploadStage(stage);
     }
 
-    setPercentComplete(percent: number) {
-        this.percentComplete = percent;
-        this.progressUpdater.setPercentComplete(percent);
-    }
-
     setFilenames(filenames: Map<number, string>) {
         this.filenames = filenames;
         this.progressUpdater.setUploadFilenames(filenames);
@@ -95,10 +87,6 @@ class UIService {
     increaseFileUploaded() {
         this.filesUploadedCount++;
         this.updateProgressBarUI();
-    }
-
-    removeFromInProgressList(key: number) {
-        this.inProgressUploads.delete(key);
     }
 
     moveFileToResultList(key: number, uploadResult: UPLOAD_RESULT) {

--- a/src/services/upload/uiService.ts
+++ b/src/services/upload/uiService.ts
@@ -19,19 +19,41 @@ class UIService {
     private perFileProgress: number;
     private filesUploaded: number;
     private totalFileCount: number;
-    private inProgressUploads: InProgressUploads;
-    private finishedUploads: FinishedUploads;
+    private uploadStage: UPLOAD_STAGES = UPLOAD_STAGES.START;
+    private percentComplete: number = 0;
+    private filenames: Map<number, string> = new Map();
+    private hasLivePhoto: boolean = false;
+    private inProgressUploads: InProgressUploads = new Map();
+    private finishedUploads: FinishedUploads = new Map();
     private progressUpdater: ProgressUpdater;
 
     init(progressUpdater: ProgressUpdater) {
         this.progressUpdater = progressUpdater;
+        this.progressUpdater.setUploadStage(this.uploadStage);
+        this.progressUpdater.setPercentComplete(this.percentComplete);
+        this.progressUpdater.setUploadFilenames(this.filenames);
+        this.progressUpdater.setHasLivePhotos(this.hasLivePhoto);
+        this.progressUpdater.setUploadCounter({
+            finished: this.filesUploaded,
+            total: this.totalFileCount,
+        });
+        this.progressUpdater.setInProgressUploads(
+            convertInProgressUploadsToList(this.inProgressUploads)
+        );
+        this.progressUpdater.setFinishedUploads(
+            segregatedFinishedUploadsToList(this.finishedUploads)
+        );
     }
 
     reset(count = 0) {
-        this.setTotalFileCount(count);
+        this.uploadStage = UPLOAD_STAGES.START;
+        this.percentComplete = 0;
+        this.filenames = new Map();
+        this.hasLivePhoto = false;
         this.filesUploaded = 0;
         this.inProgressUploads = new Map<number, number>();
         this.finishedUploads = new Map<number, UPLOAD_RESULT>();
+        this.setTotalFileCount(count);
         this.updateProgressBarUI();
     }
 
@@ -50,18 +72,22 @@ class UIService {
     }
 
     setUploadStage(stage: UPLOAD_STAGES) {
+        this.uploadStage = stage;
         this.progressUpdater.setUploadStage(stage);
     }
 
     setPercentComplete(percent: number) {
+        this.percentComplete = percent;
         this.progressUpdater.setPercentComplete(percent);
     }
 
     setFilenames(filenames: Map<number, string>) {
+        this.filenames = filenames;
         this.progressUpdater.setUploadFilenames(filenames);
     }
 
     setHasLivePhoto(hasLivePhoto: boolean) {
+        this.hasLivePhoto = hasLivePhoto;
         this.progressUpdater.setHasLivePhotos(hasLivePhoto);
     }
 

--- a/src/services/upload/uiService.ts
+++ b/src/services/upload/uiService.ts
@@ -16,16 +16,19 @@ import uploadCancelService from './uploadCancelService';
 
 const REQUEST_TIMEOUT_TIME = 30 * 1000; // 30 sec;
 class UIService {
-    private perFileProgress: number;
-    private filesUploaded: number;
-    private totalFileCount: number;
+    private progressUpdater: ProgressUpdater;
+    // UPLOAD LEVEL STATES
     private uploadStage: UPLOAD_STAGES = UPLOAD_STAGES.START;
-    private percentComplete: number = 0;
     private filenames: Map<number, string> = new Map();
     private hasLivePhoto: boolean = false;
+
+    // STAGE LEVEL STATES
+    private perFileProgress: number;
+    private filesUploadedCount: number;
+    private totalFilesCount: number;
+    private percentComplete: number = 0;
     private inProgressUploads: InProgressUploads = new Map();
     private finishedUploads: FinishedUploads = new Map();
-    private progressUpdater: ProgressUpdater;
 
     init(progressUpdater: ProgressUpdater) {
         this.progressUpdater = progressUpdater;
@@ -34,8 +37,8 @@ class UIService {
         this.progressUpdater.setUploadFilenames(this.filenames);
         this.progressUpdater.setHasLivePhotos(this.hasLivePhoto);
         this.progressUpdater.setUploadCounter({
-            finished: this.filesUploaded,
-            total: this.totalFileCount,
+            finished: this.filesUploadedCount,
+            total: this.totalFilesCount,
         });
         this.progressUpdater.setInProgressUploads(
             convertInProgressUploadsToList(this.inProgressUploads)
@@ -46,21 +49,18 @@ class UIService {
     }
 
     reset(count = 0) {
-        this.uploadStage = UPLOAD_STAGES.START;
+        this.setTotalFileCount(count);
         this.percentComplete = 0;
-        this.filenames = new Map();
-        this.hasLivePhoto = false;
-        this.filesUploaded = 0;
+        this.filesUploadedCount = 0;
         this.inProgressUploads = new Map<number, number>();
         this.finishedUploads = new Map<number, UPLOAD_RESULT>();
-        this.setTotalFileCount(count);
         this.updateProgressBarUI();
     }
 
     setTotalFileCount(count: number) {
-        this.totalFileCount = count;
+        this.totalFilesCount = count;
         if (count > 0) {
-            this.perFileProgress = 100 / this.totalFileCount;
+            this.perFileProgress = 100 / this.totalFilesCount;
         } else {
             this.perFileProgress = 0;
         }
@@ -92,7 +92,7 @@ class UIService {
     }
 
     increaseFileUploaded() {
-        this.filesUploaded++;
+        this.filesUploadedCount++;
         this.updateProgressBarUI();
     }
 
@@ -126,12 +126,12 @@ class UIService {
             setFinishedUploads,
         } = this.progressUpdater;
         setUploadCounter({
-            finished: this.filesUploaded,
-            total: this.totalFileCount,
+            finished: this.filesUploadedCount,
+            total: this.totalFilesCount,
         });
         let percentComplete =
             this.perFileProgress *
-            (this.finishedUploads.size || this.filesUploaded);
+            (this.finishedUploads.size || this.filesUploadedCount);
         if (this.inProgressUploads) {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             for (const [_, progress] of this.inProgressUploads) {

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -43,7 +43,6 @@ import {
 import { getDedicatedCryptoWorker } from 'utils/comlink/ComlinkCryptoWorker';
 
 const MAX_CONCURRENT_UPLOADS = 4;
-const FILE_UPLOAD_COMPLETED = 100;
 
 class UploadManager {
     private cryptoWorkers = new Array<
@@ -182,7 +181,6 @@ class UploadManager {
             }
         } finally {
             UIService.setUploadStage(UPLOAD_STAGES.FINISH);
-            UIService.setPercentComplete(FILE_UPLOAD_COMPLETED);
             for (let i = 0; i < MAX_CONCURRENT_UPLOADS; i++) {
                 this.cryptoWorkers[i]?.terminate();
             }

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -173,6 +173,7 @@ class UploadManager {
         } catch (e) {
             if (e.message === CustomError.UPLOAD_CANCELLED) {
                 if (isElectron()) {
+                    this.remainingFiles = [];
                     ImportService.cancelRemainingUploads();
                 }
             } else {

--- a/src/services/upload/uploadService.ts
+++ b/src/services/upload/uploadService.ts
@@ -58,7 +58,7 @@ class UploadService {
 
     async setFileCount(fileCount: number) {
         this.pendingUploadCount = fileCount;
-        this.preFetchUploadURLs();
+        await this.preFetchUploadURLs();
     }
 
     setParsedMetadataJSONMap(parsedMetadataJSONMap: ParsedMetadataJSONMap) {


### PR DESCRIPTION
## Description

- handle the unhandled exception thrown because of an un-awaited promise
- fixed  issue with upload cancel not clearing the local pending upload list properly 
- Fixed issue: if the user goes from the gallery to another page (let's say dedupe) mid-upload, then the upload progress dialog is dismissed but the upload keeps happening in the background.

- Changed default Behaviour 
   upload progress bar will now start minimized until the user manually expands it 

## Test Plan

tested locally 

