### PR TITLE
fix Photoviewer issue 

### DIFF
--- a/src/components/PhotoViewer/index.tsx
+++ b/src/components/PhotoViewer/index.tsx
@@ -115,6 +115,9 @@ function PhotoViewer(props: Iprops) {
     useEffect(() => {
         if (!photoSwipe) return;
         function handleCopyEvent() {
+            if (!isOpen || showInfo) {
+                return;
+            }
             copyToClipboardHelper(photoSwipe.currItem as EnteFile);
         }
 


### PR DESCRIPTION
## Description

- copy the image to clipboard was getting triggered when the info bar was opened, preventing from copy text from info bar

## Test Plan

tested locally