### PR TITLE
add more info to thumbnail_too_large logs

### DIFF
--- a/src/services/upload/thumbnailService.ts
+++ b/src/services/upload/thumbnailService.ts
@@ -46,6 +46,8 @@ export async function generateThumbnail(
                         thumbnailSize: convertBytesToHumanReadable(
                             thumbnail.length
                         ),
+                        fileSize: convertBytesToHumanReadable(file.size),
+                        fileType: fileTypeInfo.exactType,
                     }
                 );
             }


### PR DESCRIPTION
## Description

added actual file size while reporting a large thumbnail-generated warning 

## Test Plan

tested locally 

