### PR TITLE
Rename confusing color names

### DIFF
--- a/src/components/Collections/CollectionShare/publicShare/EnablePublicShareOptions.tsx
+++ b/src/components/Collections/CollectionShare/publicShare/EnablePublicShareOptions.tsx
@@ -90,7 +90,7 @@ export default function EnablePublicShareOptions({
                     textAlign={'center'}
                     variant="small"
                     sx={{
-                        color: (theme) => theme.colors.caution.A500,
+                        color: (theme) => theme.colors.danger.A500,
                         mt: 0.5,
                     }}>
                     {sharableLinkError}

--- a/src/components/Collections/CollectionShare/publicShare/EnablePublicShareOptions.tsx
+++ b/src/components/Collections/CollectionShare/publicShare/EnablePublicShareOptions.tsx
@@ -90,7 +90,7 @@ export default function EnablePublicShareOptions({
                     textAlign={'center'}
                     variant="small"
                     sx={{
-                        color: (theme) => theme.colors.danger.A500,
+                        color: (theme) => theme.colors.danger.A700,
                         mt: 0.5,
                     }}>
                     {sharableLinkError}

--- a/src/components/Collections/CollectionShare/publicShare/manage/index.tsx
+++ b/src/components/Collections/CollectionShare/publicShare/manage/index.tsx
@@ -150,7 +150,7 @@ export default function ManagePublicShareOptions({
                                 textAlign={'center'}
                                 variant="small"
                                 sx={{
-                                    color: (theme) => theme.colors.caution.A500,
+                                    color: (theme) => theme.colors.danger.A500,
                                     mt: 0.5,
                                 }}>
                                 {sharableLinkError}

--- a/src/components/Collections/CollectionShare/publicShare/manage/index.tsx
+++ b/src/components/Collections/CollectionShare/publicShare/manage/index.tsx
@@ -150,7 +150,7 @@ export default function ManagePublicShareOptions({
                                 textAlign={'center'}
                                 variant="small"
                                 sx={{
-                                    color: (theme) => theme.colors.danger.A500,
+                                    color: (theme) => theme.colors.danger.A700,
                                     mt: 0.5,
                                 }}>
                                 {sharableLinkError}

--- a/src/components/PasswordStrength.tsx
+++ b/src/components/PasswordStrength.tsx
@@ -21,7 +21,7 @@ export const PasswordStrengthHint = ({
                 sx={(theme) => ({
                     color:
                         passwordStrength === PasswordStrength.WEAK
-                            ? theme.colors.danger.A500
+                            ? theme.colors.danger.A700
                             : passwordStrength === PasswordStrength.MODERATE
                             ? theme.colors.warning.A500
                             : theme.colors.accent.A500,

--- a/src/components/PasswordStrength.tsx
+++ b/src/components/PasswordStrength.tsx
@@ -21,7 +21,7 @@ export const PasswordStrengthHint = ({
                 sx={(theme) => ({
                     color:
                         passwordStrength === PasswordStrength.WEAK
-                            ? theme.colors.caution.A500
+                            ? theme.colors.danger.A500
                             : passwordStrength === PasswordStrength.MODERATE
                             ? theme.colors.warning.A500
                             : theme.colors.accent.A500,

--- a/src/components/TwoFactor/InvalidInputMessage.tsx
+++ b/src/components/TwoFactor/InvalidInputMessage.tsx
@@ -7,7 +7,7 @@ const InvalidInputMessage: FC<TypographyProps> = (props) => {
         <Typography
             variant="mini"
             sx={{
-                color: (theme) => theme.colors.caution.A500,
+                color: (theme) => theme.colors.danger.A500,
             }}
             {...props}>
             {props.children}

--- a/src/components/TwoFactor/InvalidInputMessage.tsx
+++ b/src/components/TwoFactor/InvalidInputMessage.tsx
@@ -7,7 +7,7 @@ const InvalidInputMessage: FC<TypographyProps> = (props) => {
         <Typography
             variant="mini"
             sx={{
-                color: (theme) => theme.colors.danger.A500,
+                color: (theme) => theme.colors.danger.A700,
             }}
             {...props}>
             {props.children}

--- a/src/components/Upload/UploadProgress/styledComponents.tsx
+++ b/src/components/Upload/UploadProgress/styledComponents.tsx
@@ -2,8 +2,8 @@ import { styled } from '@mui/material';
 export const NotUploadSectionHeader = styled('div')(
     ({ theme }) => `
     text-align: center;
-    color: ${theme.colors.danger.A500};
-    border-bottom: 1px solid ${theme.colors.danger.A500};
+    color: ${theme.colors.danger.A700};
+    border-bottom: 1px solid ${theme.colors.danger.A700};
     margin:${theme.spacing(3, 2, 1)}
 `
 );

--- a/src/components/Upload/UploadProgress/styledComponents.tsx
+++ b/src/components/Upload/UploadProgress/styledComponents.tsx
@@ -2,8 +2,8 @@ import { styled } from '@mui/material';
 export const NotUploadSectionHeader = styled('div')(
     ({ theme }) => `
     text-align: center;
-    color: ${theme.colors.caution.A500};
-    border-bottom: 1px solid ${theme.colors.caution.A500};
+    color: ${theme.colors.danger.A500};
+    border-bottom: 1px solid ${theme.colors.danger.A500};
     margin:${theme.spacing(3, 2, 1)}
 `
 );

--- a/src/themes/colors/fixed.ts
+++ b/src/themes/colors/fixed.ts
@@ -7,10 +7,10 @@ const fixedColors: Pick<ThemeColorsOptions, keyof FixedColors> = {
         A400: '#26CB5F',
         A300: '#01DE4D',
     },
-    caution: {
+    warning: {
         A500: '#FFC247',
     },
-    warning: {
+    danger: {
         A800: '#F53434',
         A700: '#EA3F3F',
         A500: '#FF6565',

--- a/src/themes/palette/dark.tsx
+++ b/src/themes/palette/dark.tsx
@@ -21,8 +21,8 @@ const darkThemePalette: PaletteOptions = {
         contrastText: darkThemeColors.text.base,
     },
     critical: {
-        main: fixedColors.warning.A700,
-        dark: fixedColors.warning.A800,
+        main: fixedColors.danger.A700,
+        dark: fixedColors.danger.A800,
         contrastText: darkThemeColors.text.base,
     },
     background: {

--- a/src/themes/palette/light.tsx
+++ b/src/themes/palette/light.tsx
@@ -21,8 +21,8 @@ const lightThemePalette: PaletteOptions = {
         contrastText: darkThemeColors.text.base,
     },
     critical: {
-        main: fixedColors.warning.A700,
-        dark: fixedColors.warning.A800,
+        main: fixedColors.danger.A700,
+        dark: fixedColors.danger.A800,
         contrastText: darkThemeColors.text.base,
     },
     background: {

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -107,7 +107,7 @@ declare module '@mui/material/styles' {
         shadows: Shadows;
         accent: ColorStrength;
         warning: ColorStrength;
-        caution: ColorStrength;
+        danger: ColorStrength;
         blur: BlurStrength;
         white: Omit<Strength, 'faint'>;
         black: Omit<Strength, 'faint'>;
@@ -122,7 +122,7 @@ declare module '@mui/material/styles' {
         shadows?: Partial<Shadows>;
         accent?: Partial<ColorStrength>;
         warning?: Partial<ColorStrength>;
-        caution?: Partial<ColorStrength>;
+        danger?: Partial<ColorStrength>;
         blur?: Partial<BlurStrength>;
         white?: Partial<Omit<Strength, 'faint'>>;
         black?: Partial<Omit<Strength, 'faint'>>;
@@ -139,7 +139,7 @@ declare module '@mui/material/styles' {
     interface FixedColors {
         accent: string;
         warning: string;
-        caution: string;
+        danger: string;
         blur: number;
         white: string;
         black: string;


### PR DESCRIPTION
## Description

renamed confusion theme colours names. 
warning meant red and caution meant yellow, 
renaming them to danger for red and warning for yellow 

## Test Plan

tested locally 
