### PR TITLE
Add static thumb to collection cards

### DIFF
--- a/src/components/Collections/CollectionCard.tsx
+++ b/src/components/Collections/CollectionCard.tsx
@@ -3,6 +3,8 @@ import { GalleryContext } from 'pages/gallery';
 import { useState, useContext, useEffect } from 'react';
 import downloadManager from 'services/downloadManager';
 import { EnteFile } from 'types/file';
+import { StaticThumbnail } from 'components/PlaceholderThumbnails';
+import { LoadingThumbnail } from 'components/PlaceholderThumbnails';
 
 export default function CollectionCard(props: {
     children?: any;
@@ -35,7 +37,13 @@ export default function CollectionCard(props: {
 
     return (
         <CustomCollectionTile onClick={onClick}>
-            {coverImageURL && <img src={coverImageURL} />}
+            {file.metadata.hasStaticThumbnail ? (
+                <StaticThumbnail fileType={file.metadata.fileType} />
+            ) : coverImageURL ? (
+                <img src={coverImageURL} />
+            ) : (
+                <LoadingThumbnail />
+            )}
             {children}
         </CustomCollectionTile>
     );

--- a/src/components/pages/gallery/PreviewCard.tsx
+++ b/src/components/pages/gallery/PreviewCard.tsx
@@ -179,7 +179,6 @@ export const FileTypeIndicatorOverlay = styled(Overlay)(
 );
 
 const Cont = styled('div')<{ disabled: boolean }>`
-    background: #222;
     display: flex;
     width: fit-content;
     margin-bottom: ${GAP_BTW_TILES}px;


### PR DESCRIPTION
## Description

static image thumb
<img width="329" alt="image" src="https://user-images.githubusercontent.com/46242073/231729189-482f35a2-01ef-4f38-b6b7-2d15f1d1be46.png">

loading thumb 

<img width="399" alt="image" src="https://user-images.githubusercontent.com/46242073/231729290-6a07a98e-afc8-4903-8d26-81b58db80c45.png">


fixed preview card static thumbnail colour.

<img width="244" alt="image" src="https://user-images.githubusercontent.com/46242073/231729540-4127b10c-161f-4623-bb25-49a0d9fc8846.png">

## Test Plan

tested locally 