### PR TITLE
handle popup warning 

### DIFF
--- a/src/components/Sidebar/HelpSection.tsx
+++ b/src/components/Sidebar/HelpSection.tsx
@@ -3,8 +3,6 @@ import { t } from 'i18next';
 
 import ExportModal from 'components/ExportModal';
 import exportService from 'services/exportService';
-import { getEndpoint } from 'utils/common/apiUtil';
-import { getToken } from 'utils/common/key';
 import isElectron from 'is-electron';
 import { AppContext } from 'pages/_app';
 import EnteSpinner from 'components/EnteSpinner';
@@ -13,17 +11,16 @@ import { NoStyleAnchor } from 'components/pages/sharedAlbum/GoToEnte';
 import { openLink } from 'utils/common';
 import { EnteMenuItem } from 'components/Menu/EnteMenuItem';
 import { Typography } from '@mui/material';
+import { REDIRECTS, getRedirectURL } from 'constants/redirects';
 
 export default function HelpSection() {
     const [exportModalView, setExportModalView] = useState(false);
 
     const { setDialogMessage } = useContext(AppContext);
 
-    function openFeedbackURL() {
-        const feedbackURL: string = `${getEndpoint()}/users/feedback?token=${encodeURIComponent(
-            getToken()
-        )}`;
-        openLink(feedbackURL, true);
+    async function openRoadmapURL() {
+        const roadmapRedirectURL = getRedirectURL(REDIRECTS.ROADMAP);
+        openLink(roadmapRedirectURL, true);
     }
 
     function openExportModal() {
@@ -37,7 +34,7 @@ export default function HelpSection() {
     return (
         <>
             <EnteMenuItem
-                onClick={openFeedbackURL}
+                onClick={openRoadmapURL}
                 label={t('REQUEST_FEATURE')}
                 variant="secondary"
             />

--- a/src/constants/redirects/index.ts
+++ b/src/constants/redirects/index.ts
@@ -1,17 +1,7 @@
-import {
-    getRoadmapRedirectURL,
-    getFamilyPortalRedirectURL,
-} from 'services/userService';
-
 export enum REDIRECTS {
     ROADMAP = 'roadmap',
     FAMILIES = 'families',
 }
-
-export const redirectMap = new Map([
-    [REDIRECTS.ROADMAP, getRoadmapRedirectURL],
-    [REDIRECTS.FAMILIES, getFamilyPortalRedirectURL],
-]);
 
 export const getRedirectURL = (redirect: REDIRECTS) => {
     // open current app with query param of redirect = roadmap

--- a/src/constants/redirects/index.ts
+++ b/src/constants/redirects/index.ts
@@ -1,0 +1,21 @@
+import {
+    getRoadmapRedirectURL,
+    getFamilyPortalRedirectURL,
+} from 'services/userService';
+
+export enum REDIRECTS {
+    ROADMAP = 'roadmap',
+    FAMILIES = 'families',
+}
+
+export const redirectMap = new Map([
+    [REDIRECTS.ROADMAP, getRoadmapRedirectURL],
+    [REDIRECTS.FAMILIES, getFamilyPortalRedirectURL],
+]);
+
+export const getRedirectURL = (redirect: REDIRECTS) => {
+    // open current app with query param of redirect = roadmap
+    const url = new URL(window.location.href);
+    url.searchParams.set('redirect', redirect);
+    return url.href;
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -73,10 +73,11 @@ import {
     CLIENT_PACKAGE_NAMES,
     getAppNameAndTitle,
 } from 'constants/apps';
+import { REDIRECTS } from 'constants/redirects';
 
 const redirectMap = new Map([
-    ['roadmap', getRoadmapRedirectURL],
-    ['families', getFamilyPortalRedirectURL],
+    [REDIRECTS.ROADMAP, getRoadmapRedirectURL],
+    [REDIRECTS.FAMILIES, getFamilyPortalRedirectURL],
 ]);
 
 export const MessageContainer = styled('div')`

--- a/src/utils/billing/index.ts
+++ b/src/utils/billing/index.ts
@@ -7,11 +7,11 @@ import { SetLoading } from 'types/gallery';
 import { getData, LS_KEYS } from '../storage/localStorage';
 import { logError } from '../sentry';
 import { SetDialogBoxAttributes } from 'types/dialogBox';
-import { getFamilyPortalRedirectURL } from 'services/userService';
 import { openLink } from 'utils/common';
 import { isPartOfFamily, getTotalFamilyUsage } from 'utils/user/family';
 import { UserDetails } from 'types/user';
 import { getSubscriptionPurchaseSuccessMessage } from 'utils/ui';
+import { getRedirectURL, REDIRECTS } from 'constants/redirects';
 
 const PAYMENT_PROVIDER_STRIPE = 'stripe';
 const PAYMENT_PROVIDER_APPSTORE = 'appstore';
@@ -234,8 +234,8 @@ export async function manageFamilyMethod(
 ) {
     try {
         setLoading(true);
-        const url = await getFamilyPortalRedirectURL();
-        openLink(url, true);
+        const familyPortalRedirectURL = getRedirectURL(REDIRECTS.FAMILIES);
+        openLink(familyPortalRedirectURL, true);
     } catch (error) {
         logError(error, 'failed to redirect to family portal');
         setDialogMessage({


### PR DESCRIPTION
## Description

### Problem 

In the case of `families` portal, we generate the link after getting a JWT token from the server. (async call), causing  the `window.open` call **not** being made just after (in the same tick) the user presses the button, but after some interval.
 The browser thinks that this is a random popup we are trying to open without any user input and blocks it.

### Solution 

What I have done for now is that instead of trying to fetch the token and then redirecting the user to the link in a new tab.
I redirect him to the static link `web.ente.io?redirect=familes` and the web app which opens on that page, fetches the token and then redirects to the family portal URL.

## Test Plan

tested locally 
