### PR TITLE
Fix empty screen dedupe

### DIFF
--- a/src/components/GalleryEmptyState.tsx
+++ b/src/components/GalleryEmptyState.tsx
@@ -1,6 +1,4 @@
-import React, { useContext } from 'react';
 import { Button, Stack, styled, Typography } from '@mui/material';
-import { DeduplicateContext } from 'pages/deduplicate';
 import VerticallyCentered, { FlexWrapper } from './Container';
 import { Box } from '@mui/material';
 import uploadManager from 'services/upload/uploadManager';
@@ -21,19 +19,8 @@ const NonDraggableImage = styled('img')`
     pointer-events: none;
 `;
 
-export default function EmptyScreen({ openUploader }) {
-    const deduplicateContext = useContext(DeduplicateContext);
-    return deduplicateContext.isOnDeduplicatePage ? (
-        <VerticallyCentered>
-            <div
-                style={{
-                    color: '#a6a6a6',
-                    fontSize: '18px',
-                }}>
-                {t('NO_DUPLICATES_FOUND')}
-            </div>
-        </VerticallyCentered>
-    ) : (
+export default function GalleryEmptyState({ openUploader }) {
+    return (
         <Wrapper>
             <Stack
                 sx={{

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -18,7 +18,6 @@ import { MergedSourceURL, SelectedState } from 'types/gallery';
 import PublicCollectionDownloadManager from 'services/publicCollectionDownloadManager';
 import { PublicCollectionGalleryContext } from 'utils/publicCollectionGallery';
 import { useRouter } from 'next/router';
-import EmptyScreen from './EmptyScreen';
 import { AppContext } from 'pages/_app';
 import { DeduplicateContext } from 'pages/deduplicate';
 import { IsArchived } from 'utils/magicMetadata';
@@ -57,9 +56,6 @@ interface Props {
         selected: SelectedState | ((selected: SelectedState) => SelectedState)
     ) => void;
     selected: SelectedState;
-    isFirstLoad?;
-    hasNoPersonalFiles?;
-    openUploader?;
     isInSearchMode?: boolean;
     search?: Search;
     deletedFileIds?: Set<number>;
@@ -79,9 +75,6 @@ const PhotoFrame = ({
     archivedCollections,
     setSelected,
     selected,
-    isFirstLoad,
-    hasNoPersonalFiles,
-    openUploader,
     isInSearchMode,
     search,
     deletedFileIds,
@@ -653,49 +646,40 @@ const PhotoFrame = ({
     };
 
     return (
-        <>
-            {!isFirstLoad &&
-            hasNoPersonalFiles &&
-            !isInSearchMode &&
-            activeCollection === ALL_SECTION ? (
-                <EmptyScreen openUploader={openUploader} />
-            ) : (
-                <Container>
-                    <AutoSizer>
-                        {({ height, width }) => (
-                            <PhotoList
-                                width={width}
-                                height={height}
-                                getThumbnail={getThumbnail}
-                                filteredData={filteredData}
-                                activeCollection={activeCollection}
-                                showAppDownloadBanner={
-                                    files.length < 30 &&
-                                    !isInSearchMode &&
-                                    !deduplicateContext.isOnDeduplicatePage
-                                }
-                            />
-                        )}
-                    </AutoSizer>
-                    <PhotoViewer
-                        isOpen={open}
-                        items={filteredData}
-                        currentIndex={currentIndex}
-                        onClose={handleClose}
-                        gettingData={getSlideData}
-                        favItemIds={favItemIds}
-                        deletedFileIds={deletedFileIds}
-                        setDeletedFileIds={setDeletedFileIds}
-                        isIncomingSharedCollection={isIncomingSharedCollection}
-                        isTrashCollection={activeCollection === TRASH_SECTION}
-                        enableDownload={enableDownload}
-                        isSourceLoaded={isSourceLoaded}
-                        fileToCollectionsMap={fileToCollectionsMap}
-                        collectionNameMap={collectionNameMap}
+        <Container>
+            <AutoSizer>
+                {({ height, width }) => (
+                    <PhotoList
+                        width={width}
+                        height={height}
+                        getThumbnail={getThumbnail}
+                        filteredData={filteredData}
+                        activeCollection={activeCollection}
+                        showAppDownloadBanner={
+                            files.length < 30 &&
+                            !isInSearchMode &&
+                            !deduplicateContext.isOnDeduplicatePage
+                        }
                     />
-                </Container>
-            )}
-        </>
+                )}
+            </AutoSizer>
+            <PhotoViewer
+                isOpen={open}
+                items={filteredData}
+                currentIndex={currentIndex}
+                onClose={handleClose}
+                gettingData={getSlideData}
+                favItemIds={favItemIds}
+                deletedFileIds={deletedFileIds}
+                setDeletedFileIds={setDeletedFileIds}
+                isIncomingSharedCollection={isIncomingSharedCollection}
+                isTrashCollection={activeCollection === TRASH_SECTION}
+                enableDownload={enableDownload}
+                isSourceLoaded={isSourceLoaded}
+                fileToCollectionsMap={fileToCollectionsMap}
+                collectionNameMap={collectionNameMap}
+            />
+        </Container>
     );
 };
 

--- a/src/pages/deduplicate/index.tsx
+++ b/src/pages/deduplicate/index.tsx
@@ -28,6 +28,7 @@ import { syncCollections } from 'services/collectionService';
 import EnteSpinner from 'components/EnteSpinner';
 import VerticallyCentered from 'components/Container';
 import { Collection } from 'types/collection';
+import Typography from '@mui/material/Typography';
 
 export const DeduplicateContext = createContext<DeduplicateContextType>(
     DefaultDeduplicateContext
@@ -179,15 +180,23 @@ export default function Deduplicate() {
                     })}
                 </Info>
             )}
-            <PhotoFrame
-                files={duplicateFiles}
-                collections={collections}
-                syncWithRemote={syncWithRemote}
-                setSelected={setSelected}
-                selected={selected}
-                activeCollection={ALL_SECTION}
-                isDeduplicating
-            />
+            {duplicateFiles.length === 0 ? (
+                <VerticallyCentered>
+                    <Typography variant="large" color="text.muted">
+                        {t('NO_DUPLICATES_FOUND')}
+                    </Typography>
+                </VerticallyCentered>
+            ) : (
+                <PhotoFrame
+                    files={duplicateFiles}
+                    collections={collections}
+                    syncWithRemote={syncWithRemote}
+                    setSelected={setSelected}
+                    selected={selected}
+                    activeCollection={ALL_SECTION}
+                    isDeduplicating
+                />
+            )}
             <DeduplicateOptions
                 deleteFileHelper={deleteFileHelper}
                 count={selected.count}

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -109,6 +109,7 @@ import { SYNC_INTERVAL_IN_MICROSECONDS } from 'constants/gallery';
 import ElectronService from 'services/electron/common';
 import uploadManager from 'services/upload/uploadManager';
 import { getToken } from 'utils/common/key';
+import GalleryEmptyState from 'components/GalleryEmptyState';
 
 export const DeadCenter = styled('div')`
     flex: 1;
@@ -714,28 +715,32 @@ export default function Gallery() {
                     sidebarView={sidebarView}
                     closeSidebar={closeSidebar}
                 />
-                <PhotoFrame
-                    files={files}
-                    collections={collections}
-                    syncWithRemote={syncWithRemote}
-                    favItemIds={favItemIds}
-                    archivedCollections={archivedCollections}
-                    setSelected={setSelected}
-                    selected={selected}
-                    isFirstLoad={isFirstLoad}
-                    hasNoPersonalFiles={hasNoPersonalFiles}
-                    openUploader={openUploader}
-                    isInSearchMode={isInSearchMode}
-                    search={search}
-                    deletedFileIds={deletedFileIds}
-                    setDeletedFileIds={setDeletedFileIds}
-                    activeCollection={activeCollection}
-                    isIncomingSharedCollection={
-                        collectionSummaries.get(activeCollection)?.type ===
-                        CollectionSummaryType.incomingShare
-                    }
-                    enableDownload={true}
-                />
+                {!isInSearchMode &&
+                !isFirstLoad &&
+                hasNoPersonalFiles &&
+                activeCollection === ALL_SECTION ? (
+                    <GalleryEmptyState openUploader={openUploader} />
+                ) : (
+                    <PhotoFrame
+                        files={files}
+                        collections={collections}
+                        syncWithRemote={syncWithRemote}
+                        favItemIds={favItemIds}
+                        archivedCollections={archivedCollections}
+                        setSelected={setSelected}
+                        selected={selected}
+                        isInSearchMode={isInSearchMode}
+                        search={search}
+                        deletedFileIds={deletedFileIds}
+                        setDeletedFileIds={setDeletedFileIds}
+                        activeCollection={activeCollection}
+                        isIncomingSharedCollection={
+                            collectionSummaries.get(activeCollection)?.type ===
+                            CollectionSummaryType.incomingShare
+                        }
+                        enableDownload={true}
+                    />
+                )}
                 {selected.count > 0 &&
                     selected.collectionID === activeCollection && (
                         <SelectedFileOptions

--- a/src/pages/shared-albums/index.tsx
+++ b/src/pages/shared-albums/index.tsx
@@ -400,7 +400,6 @@ export default function PublicCollectionGallery() {
                     syncWithRemote={syncWithRemote}
                     setSelected={() => null}
                     selected={{ count: 0, collectionID: null, ownCount: 0 }}
-                    isFirstLoad={true}
                     activeCollection={ALL_SECTION}
                     isIncomingSharedCollection
                     enableDownload={


### PR DESCRIPTION
## Description

### Issue 
Empty screen for dedupe page missing empty state message

### Solution 
Refactored EmptyState logic out of `PhotoFrame` component, preventing the unwanted effect of changes done for the gallery page affecting other pages 

## Test Plan

- tested normal and empty state for gallery and dedupe and shared-albums page  
