### PR TITLE
fix favorite name undefined issue 

### DIFF
--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -1001,7 +1001,10 @@ export async function getCollectionSummaries(
 
     const favCollection = await getFavCollection();
     if (favCollection) {
-        collectionSummaries.get(favCollection.id).name = t('FAVORITES');
+        const favoriteEntry = collectionSummaries.get(favCollection.id);
+        if (favoriteEntry) {
+            collectionSummaries.get(favCollection.id).name = t('FAVORITES');
+        }
     }
 
     collectionSummaries.set(


### PR DESCRIPTION
## Description

Fixes issue in testing introduced by https://github.com/ente-io/photos-web/pull/1092/commits/f173525995385d405ddc5cf3392ac5d346bea8c8 

add a check to prevent reading `favorites` name from `collectionSummary` in case it is removed from the list, for if it was empty 

## Test Plan

tested locally 
