### PR TITLE
Open roadmap in browser (desktop)

### DIFF
--- a/apps/photos/src/constants/redirects/index.ts
+++ b/apps/photos/src/constants/redirects/index.ts
@@ -5,7 +5,7 @@ export enum REDIRECTS {
 
 export const getRedirectURL = (redirect: REDIRECTS) => {
     // open current app with query param of redirect = roadmap
-    const url = new URL(window.location.href);
+    const url = new URL('https://web.ente.io');
     url.searchParams.set('redirect', redirect);
     return url.href;
 };

--- a/apps/photos/src/constants/redirects/index.ts
+++ b/apps/photos/src/constants/redirects/index.ts
@@ -4,7 +4,6 @@ export enum REDIRECTS {
 }
 
 export const getRedirectURL = (redirect: REDIRECTS) => {
-    // open current app with query param of redirect = roadmap
     const url = new URL('https://web.ente.io');
     url.searchParams.set('redirect', redirect);
     return url.href;


### PR DESCRIPTION
## Description

- The desktop app is currently opening the roadmap link in an electron window.
Changing the redirection root URL to `https://web.ente.io` to force opening the link in external browser 

## Test Plan

tested locally 
