### PR TITLE
Fix grouping based on hashes on dedupe page 

### DIFF
--- a/apps/photos/src/components/PhotoList.tsx
+++ b/apps/photos/src/components/PhotoList.tsx
@@ -342,27 +342,40 @@ export function PhotoList({
     const groupByFileSize = (timeStampList: TimeStampListItem[]) => {
         let index = 0;
         while (index < displayFiles.length) {
-            const currentFile = displayFiles[index];
-            const currentFileSize = deduplicateContext.fileSizeMap.get(
-                currentFile.id
+            const firstFile = displayFiles[index];
+            const firstFileSize = deduplicateContext.fileSizeMap.get(
+                firstFile.id
             );
-            const currentCreationTime = currentFile.metadata.creationTime;
+            const firstFileCreationTime = firstFile.metadata.creationTime;
             let lastFileIndex = index;
 
             while (lastFileIndex < displayFiles.length) {
+                const lastFile = displayFiles[lastFileIndex];
+
+                const lastFileSize = deduplicateContext.fileSizeMap.get(
+                    lastFile.id
+                );
+                if (lastFileSize !== firstFileSize) {
+                    break;
+                }
+
+                const lastFileCreationTime = lastFile.metadata.creationTime;
                 if (
-                    deduplicateContext.fileSizeMap.get(
-                        displayFiles[lastFileIndex].id
-                    ) !== currentFileSize ||
-                    (deduplicateContext.clubSameTimeFilesOnly &&
-                        displayFiles[lastFileIndex].metadata.creationTime !==
-                            currentCreationTime) ||
-                    ((hasFileHash(displayFiles[lastFileIndex].metadata) ||
-                        hasFileHash(currentFile.metadata)) &&
-                        !areFilesWithFileHashSame(
-                            displayFiles[lastFileIndex].metadata,
-                            currentFile.metadata
-                        ))
+                    deduplicateContext.clubSameTimeFilesOnly &&
+                    lastFileCreationTime !== firstFileCreationTime
+                ) {
+                    break;
+                }
+
+                const eitherFileHasFileHash =
+                    hasFileHash(lastFile.metadata) ||
+                    hasFileHash(firstFile.metadata);
+                if (
+                    eitherFileHasFileHash &&
+                    !areFilesWithFileHashSame(
+                        lastFile.metadata,
+                        firstFile.metadata
+                    )
                 ) {
                     break;
                 }
@@ -371,7 +384,7 @@ export function PhotoList({
             lastFileIndex--;
             timeStampList.push({
                 itemType: ITEM_TYPE.SIZE_AND_COUNT,
-                fileSize: currentFileSize,
+                fileSize: firstFileSize,
                 fileCount: lastFileIndex - index + 1,
             });
 

--- a/apps/photos/src/components/PhotoList.tsx
+++ b/apps/photos/src/components/PhotoList.tsx
@@ -22,6 +22,7 @@ import { GalleryContext } from 'pages/gallery';
 import { formatDate } from 'utils/time/format';
 import { Trans } from 'react-i18next';
 import { t } from 'i18next';
+import { areFilesWithFileHashSame, hasFileHash } from 'utils/upload';
 
 const A_DAY = 24 * 60 * 60 * 1000;
 const FOOTER_HEIGHT = 90;
@@ -341,9 +342,11 @@ export function PhotoList({
     const groupByFileSize = (timeStampList: TimeStampListItem[]) => {
         let index = 0;
         while (index < displayFiles.length) {
-            const file = displayFiles[index];
-            const currentFileSize = deduplicateContext.fileSizeMap.get(file.id);
-            const currentCreationTime = file.metadata.creationTime;
+            const currentFile = displayFiles[index];
+            const currentFileSize = deduplicateContext.fileSizeMap.get(
+                currentFile.id
+            );
+            const currentCreationTime = currentFile.metadata.creationTime;
             let lastFileIndex = index;
 
             while (lastFileIndex < displayFiles.length) {
@@ -353,7 +356,13 @@ export function PhotoList({
                     ) !== currentFileSize ||
                     (deduplicateContext.clubSameTimeFilesOnly &&
                         displayFiles[lastFileIndex].metadata.creationTime !==
-                            currentCreationTime)
+                            currentCreationTime) ||
+                    ((hasFileHash(displayFiles[lastFileIndex].metadata) ||
+                        hasFileHash(currentFile.metadata)) &&
+                        !areFilesWithFileHashSame(
+                            displayFiles[lastFileIndex].metadata,
+                            currentFile.metadata
+                        ))
                 ) {
                     break;
                 }


### PR DESCRIPTION
## Description

^ title 

## Test Plan

tested locally by uploading a file multiple copies, some with hash and some without hash
