### PR TITLE
Show disk cached thumb on scroll

### DIFF
--- a/apps/photos/src/components/pages/gallery/PreviewCard.tsx
+++ b/apps/photos/src/components/pages/gallery/PreviewCard.tsx
@@ -240,7 +240,7 @@ export default function PreviewCard(props: IProps) {
     useEffect(() => {
         const main = async () => {
             try {
-                if (imgSrc) {
+                if (file.msrc) {
                     return;
                 }
                 let url: string;

--- a/apps/photos/src/components/pages/gallery/PreviewCard.tsx
+++ b/apps/photos/src/components/pages/gallery/PreviewCard.tsx
@@ -238,13 +238,34 @@ export default function PreviewCard(props: IProps) {
     }, []);
 
     useEffect(() => {
-        if (!file.msrc && !props.showPlaceholder) {
-            const main = async () => {
-                try {
-                    let url;
-                    if (thumbs.has(file.id)) {
-                        url = thumbs.get(file.id);
+        const main = async () => {
+            try {
+                if (imgSrc) {
+                    return;
+                }
+                let url: string;
+                // check in in-memory cache
+                if (thumbs.has(file.id)) {
+                    url = thumbs.get(file.id);
+                } else {
+                    // check in cacheStorage
+                    if (
+                        publicCollectionGalleryContext.accessedThroughSharedURL
+                    ) {
+                        url;
+                        await PublicCollectionDownloadManager.getCachedThumbnail(
+                            file
+                        );
                     } else {
+                        url = await DownloadManager.getCachedThumbnail(file);
+                    }
+                    if (url) {
+                        thumbs.set(file.id, url);
+                    } else {
+                        // download thumbnail
+                        if (props.showPlaceholder) {
+                            return;
+                        }
                         if (
                             publicCollectionGalleryContext.accessedThroughSharedURL
                         ) {
@@ -259,18 +280,18 @@ export default function PreviewCard(props: IProps) {
                         }
                         thumbs.set(file.id, url);
                     }
-                    if (!isMounted.current) {
-                        return;
-                    }
-                    setImgSrc(url);
-                    updateURL(file.id, url);
-                } catch (e) {
-                    logError(e, 'preview card useEffect failed');
-                    // no-op
                 }
-            };
-            main();
-        }
+                if (!isMounted.current) {
+                    return;
+                }
+                setImgSrc(url);
+                updateURL(file.id, url);
+            } catch (e) {
+                logError(e, 'preview card useEffect failed');
+                // no-op
+            }
+        };
+        main();
     }, [props.showPlaceholder]);
 
     const handleClick = () => {

--- a/apps/photos/src/components/pages/gallery/PreviewCard.tsx
+++ b/apps/photos/src/components/pages/gallery/PreviewCard.tsx
@@ -252,10 +252,10 @@ export default function PreviewCard(props: IProps) {
                     if (
                         publicCollectionGalleryContext.accessedThroughSharedURL
                     ) {
-                        url;
-                        await PublicCollectionDownloadManager.getCachedThumbnail(
-                            file
-                        );
+                        url =
+                            await PublicCollectionDownloadManager.getCachedThumbnail(
+                                file
+                            );
                     } else {
                         url = await DownloadManager.getCachedThumbnail(file);
                     }

--- a/apps/photos/src/services/downloadManager.ts
+++ b/apps/photos/src/services/downloadManager.ts
@@ -11,14 +11,11 @@ import { EnteFile } from 'types/file';
 import { logError } from 'utils/sentry';
 import { FILE_TYPE } from 'constants/file';
 import { CustomError } from 'utils/error';
-import QueueProcessor, { PROCESSING_STRATEGY } from './queueProcessor';
 import ComlinkCryptoWorker from 'utils/comlink/ComlinkCryptoWorker';
 import { CacheStorageService } from './cache/cacheStorageService';
 import { CACHES } from 'constants/cache';
 import { Remote } from 'comlink';
 import { DedicatedCryptoWorker } from 'worker/crypto.worker';
-
-const MAX_PARALLEL_DOWNLOADS = 10;
 
 class DownloadManager {
     private fileObjectURLPromise = new Map<
@@ -26,11 +23,6 @@ class DownloadManager {
         Promise<{ original: string[]; converted: string[] }>
     >();
     private thumbnailObjectURLPromise = new Map<number, Promise<string>>();
-
-    private thumbnailDownloadRequestsProcessor = new QueueProcessor<any>(
-        MAX_PARALLEL_DOWNLOADS,
-        PROCESSING_STRATEGY.LIFO
-    );
 
     public async getThumbnail(
         file: EnteFile,
@@ -55,16 +47,12 @@ class DownloadManager {
                     if (cacheResp) {
                         return URL.createObjectURL(await cacheResp.blob());
                     }
-                    const thumb =
-                        await this.thumbnailDownloadRequestsProcessor.queueUpRequest(
-                            () =>
-                                this.downloadThumb(
-                                    token,
-                                    file,
-                                    usingWorker,
-                                    timeout
-                                )
-                        ).promise;
+                    const thumb = await this.downloadThumb(
+                        token,
+                        file,
+                        usingWorker,
+                        timeout
+                    );
                     const thumbBlob = new Blob([thumb]);
 
                     thumbnailCache

--- a/apps/photos/src/services/downloadManager.ts
+++ b/apps/photos/src/services/downloadManager.ts
@@ -16,6 +16,7 @@ import { CacheStorageService } from './cache/cacheStorageService';
 import { CACHES } from 'constants/cache';
 import { Remote } from 'comlink';
 import { DedicatedCryptoWorker } from 'worker/crypto.worker';
+import { LimitedCache } from 'types/cache';
 
 class DownloadManager {
     private fileObjectURLPromise = new Map<
@@ -23,6 +24,40 @@ class DownloadManager {
         Promise<{ original: string[]; converted: string[] }>
     >();
     private thumbnailObjectURLPromise = new Map<number, Promise<string>>();
+
+    private async getThumbnailCache() {
+        try {
+            const thumbnailCache = await CacheStorageService.open(
+                CACHES.THUMBS
+            );
+            return thumbnailCache;
+        } catch (e) {
+            return null;
+            // ignore
+        }
+    }
+
+    public async getCachedThumbnail(
+        file: EnteFile,
+        thumbnailCache?: LimitedCache
+    ) {
+        try {
+            if (!thumbnailCache) {
+                thumbnailCache = await this.getThumbnailCache();
+            }
+            const cacheResp: Response = await thumbnailCache?.match(
+                file.id.toString()
+            );
+
+            if (cacheResp) {
+                return URL.createObjectURL(await cacheResp.blob());
+            }
+            return null;
+        } catch (e) {
+            logError(e, 'failed to get cached thumbnail');
+            throw e;
+        }
+    }
 
     public async getThumbnail(
         file: EnteFile,
@@ -37,15 +72,13 @@ class DownloadManager {
             }
             if (!this.thumbnailObjectURLPromise.has(file.id)) {
                 const downloadPromise = async () => {
-                    const thumbnailCache = await CacheStorageService.open(
-                        CACHES.THUMBS
+                    const thumbnailCache = await this.getThumbnailCache();
+                    const cachedThumb = await this.getCachedThumbnail(
+                        file,
+                        thumbnailCache
                     );
-
-                    const cacheResp: Response = await thumbnailCache?.match(
-                        file.id.toString()
-                    );
-                    if (cacheResp) {
-                        return URL.createObjectURL(await cacheResp.blob());
+                    if (cachedThumb) {
+                        return cachedThumb;
                     }
                     const thumb = await this.downloadThumb(
                         token,

--- a/apps/photos/src/services/publicCollectionDownloadManager.ts
+++ b/apps/photos/src/services/publicCollectionDownloadManager.ts
@@ -13,7 +13,6 @@ import { EnteFile } from 'types/file';
 import { logError } from 'utils/sentry';
 import { FILE_TYPE } from 'constants/file';
 import { CustomError } from 'utils/error';
-import QueueProcessor from './queueProcessor';
 import ComlinkCryptoWorker from 'utils/comlink/ComlinkCryptoWorker';
 import { CACHES } from 'constants/cache';
 import { CacheStorageService } from './cache/cacheStorageService';
@@ -25,8 +24,6 @@ class PublicCollectionDownloadManager {
         Promise<{ original: string[]; converted: string[] }>
     >();
     private thumbnailObjectURLPromise = new Map<number, Promise<string>>();
-
-    private thumbnailDownloadRequestsProcessor = new QueueProcessor<any>(5);
 
     private async getThumbnailCache() {
         try {
@@ -83,10 +80,11 @@ class PublicCollectionDownloadManager {
                         return cachedThumb;
                     }
 
-                    const thumb =
-                        await this.thumbnailDownloadRequestsProcessor.queueUpRequest(
-                            () => this.downloadThumb(token, passwordToken, file)
-                        ).promise;
+                    const thumb = await this.downloadThumb(
+                        token,
+                        passwordToken,
+                        file
+                    );
                     const thumbBlob = new Blob([thumb]);
                     try {
                         await thumbnailCache?.put(


### PR DESCRIPTION
## Description

- added support to check if the file has a disk Cached thumbnail and show it instead of the scroll placeholder.
- Also removed the thumbnail download rate limiter.


### Future 
The downloadManager and public DownloadManager can be merged...most of the stuff in them are similar will only difference being the API. Will do this in a future PR to keep this one clean 

## Test Plan

tested with gallery and shared-albums files 
