### PR TITLE
Fix  opacity 0% backdrop blocking ui for firefox

### DIFF
--- a/apps/photos/src/themes/index.ts
+++ b/apps/photos/src/themes/index.ts
@@ -18,6 +18,9 @@ export const getTheme = (themeColor: THEME_COLOR, appName: APPS) => {
         shape: {
             borderRadius: 8,
         },
+        transitions: {
+            duration: { leavingScreen: 300 },
+        },
     });
     return theme;
 };


### PR DESCRIPTION
## Description
Firefox doesn't support `:has`  pseudo selector so this fix doesn't work https://github.com/ente-io/photos-web/pull/1117

For now, delaying the end animation to 300ms  (default 178ms) seems to have done the trick and Jishnu and I both are now not able to reproduce the issue.

## Test Plan

tested by jishnu  