### PR TITLE
Improve update magic metadata functions

### DIFF
--- a/apps/photos/src/components/Collections/CollectionListBar/index.tsx
+++ b/apps/photos/src/components/Collections/CollectionListBar/index.tsx
@@ -75,6 +75,10 @@ const CollectionCardContainer = React.memo(
     areEqual
 );
 
+const getItemKey = (index: number, data: ItemData) => {
+    return `${data.collectionSummaries[index].id}-${data.collectionSummaries[index].latestFile?.id}`;
+};
+
 const CollectionListBar = (props: IProps) => {
     const {
         activeCollection,
@@ -153,6 +157,7 @@ const CollectionListBar = (props: IProps) => {
                                 layout="horizontal"
                                 width={width}
                                 height={110}
+                                itemKey={getItemKey}
                                 itemCount={collectionSummaries.length}
                                 itemSize={CollectionListBarCardWidth}
                                 useIsScrolling>

--- a/apps/photos/src/components/PhotoViewer/FileInfo/RenderCaption.tsx
+++ b/apps/photos/src/components/PhotoViewer/FileInfo/RenderCaption.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { updateFilePublicMagicMetadata } from 'services/fileService';
 import { EnteFile } from 'types/file';
 import { changeCaption, updateExistingFilePubMetadata } from 'utils/file';
 import { logError } from 'utils/sentry';
@@ -41,10 +40,7 @@ export function RenderCaption({
                 }
                 setCaption(newCaption);
 
-                let updatedFile = await changeCaption(file, newCaption);
-                updatedFile = (
-                    await updateFilePublicMagicMetadata([updatedFile])
-                )[0];
+                const updatedFile = await changeCaption(file, newCaption);
                 updateExistingFilePubMetadata(file, updatedFile);
                 file.title = file.pubMagicMetadata.data.caption;
                 refreshPhotoswipe();

--- a/apps/photos/src/components/PhotoViewer/FileInfo/RenderCreationTime.tsx
+++ b/apps/photos/src/components/PhotoViewer/FileInfo/RenderCreationTime.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { updateFilePublicMagicMetadata } from 'services/fileService';
 import { EnteFile } from 'types/file';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import {
@@ -37,13 +36,10 @@ export function RenderCreationTime({
                     closeEditMode();
                     return;
                 }
-                let updatedFile = await changeFileCreationTime(
+                const updatedFile = await changeFileCreationTime(
                     file,
                     unixTimeInMicroSec
                 );
-                updatedFile = (
-                    await updateFilePublicMagicMetadata([updatedFile])
-                )[0];
                 updateExistingFilePubMetadata(file, updatedFile);
                 scheduleUpdate();
             }

--- a/apps/photos/src/components/PhotoViewer/FileInfo/RenderFileName.tsx
+++ b/apps/photos/src/components/PhotoViewer/FileInfo/RenderFileName.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { updateFilePublicMagicMetadata } from 'services/fileService';
 import { EnteFile } from 'types/file';
 import {
     changeFileName,
@@ -82,10 +81,7 @@ export function RenderFileName({
                 }
                 setFilename(newFilename);
                 const newTitle = getFileTitle(newFilename, extension);
-                let updatedFile = await changeFileName(file, newTitle);
-                updatedFile = (
-                    await updateFilePublicMagicMetadata([updatedFile])
-                )[0];
+                const updatedFile = await changeFileName(file, newTitle);
                 updateExistingFilePubMetadata(file, updatedFile);
                 scheduleUpdate();
             }

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -11,7 +11,6 @@ import { clearKeys, getKey, SESSION_KEYS } from 'utils/storage/sessionStorage';
 import {
     getLocalFiles,
     syncFiles,
-    updateFileMagicMetadata,
     trashFiles,
     deleteFromTrash,
     getLocalHiddenFiles,
@@ -658,11 +657,7 @@ export default function Gallery() {
         startLoading();
         try {
             const selectedFiles = getSelectedFiles(selected, filteredData);
-            const updatedFiles = await changeFilesVisibility(
-                selectedFiles,
-                visibility
-            );
-            await updateFileMagicMetadata(updatedFiles);
+            await changeFilesVisibility(selectedFiles, visibility);
             clearSelection();
         } catch (e) {
             logError(e, 'change file visibility failed');

--- a/apps/photos/src/services/collectionService.ts
+++ b/apps/photos/src/services/collectionService.ts
@@ -47,7 +47,7 @@ import {
     SUB_TYPE,
     UpdateMagicMetadataRequest,
 } from 'types/magicMetadata';
-import { IsArchived, updateMagicMetadataProps } from 'utils/magicMetadata';
+import { IsArchived, updateMagicMetadata } from 'utils/magicMetadata';
 import { User } from 'types/user';
 import {
     isQuickLinkCollection,
@@ -58,6 +58,7 @@ import {
     isHiddenCollection,
     isValidReplacementAlbum,
     getNonHiddenCollections,
+    changeCollectionSubType,
 } from 'utils/collection';
 import ComlinkCryptoWorker from 'utils/comlink/ComlinkCryptoWorker';
 import { getLocalFiles } from './fileService';
@@ -345,7 +346,7 @@ const createCollection = async (
             await cryptoWorker.encryptUTF8(collectionName, collectionKey);
         let encryptedMagicMetadata: EncryptedMagicMetadata;
         if (magicMetadataProps) {
-            const magicMetadata = await updateMagicMetadataProps(
+            const magicMetadata = await updateMagicMetadata(
                 NEW_COLLECTION_MAGIC_METADATA,
                 null,
                 magicMetadataProps
@@ -711,7 +712,10 @@ export const leaveSharedAlbum = async (collectionID: number) => {
     }
 };
 
-export const updateCollectionMagicMetadata = async (collection: Collection) => {
+export const updateCollectionMagicMetadata = async (
+    collection: Collection,
+    updatedMagicMetadata: CollectionMagicMetadata
+) => {
     const token = getToken();
     if (!token) {
         return;
@@ -720,15 +724,15 @@ export const updateCollectionMagicMetadata = async (collection: Collection) => {
     const cryptoWorker = await ComlinkCryptoWorker.getInstance();
 
     const { file: encryptedMagicMetadata } = await cryptoWorker.encryptMetadata(
-        collection.magicMetadata.data,
+        updatedMagicMetadata.data,
         collection.key
     );
 
     const reqBody: UpdateMagicMetadataRequest = {
         id: collection.id,
         magicMetadata: {
-            version: collection.magicMetadata.version,
-            count: collection.magicMetadata.count,
+            version: updatedMagicMetadata.version,
+            count: updatedMagicMetadata.count,
             data: encryptedMagicMetadata.encryptedData,
             header: encryptedMagicMetadata.decryptionHeader,
         },
@@ -745,8 +749,8 @@ export const updateCollectionMagicMetadata = async (collection: Collection) => {
     const updatedCollection: Collection = {
         ...collection,
         magicMetadata: {
-            ...collection.magicMetadata,
-            version: collection.magicMetadata.version + 1,
+            ...updatedMagicMetadata,
+            version: updatedMagicMetadata.version + 1,
         },
     };
     return updatedCollection;
@@ -758,7 +762,7 @@ export const renameCollection = async (
 ) => {
     if (isQuickLinkCollection(collection)) {
         // Convert quick link collection to normal collection on rename
-        await updateCollectionSubType(collection, SUB_TYPE.DEFAULT);
+        await changeCollectionSubType(collection, SUB_TYPE.DEFAULT);
     }
     const token = getToken();
     const cryptoWorker = await ComlinkCryptoWorker.getInstance();
@@ -777,24 +781,6 @@ export const renameCollection = async (
             'X-Auth-Token': token,
         }
     );
-};
-
-const updateCollectionSubType = async (
-    collection: Collection,
-    subType: SUB_TYPE
-) => {
-    const updatedMagicMetadataProps: CollectionMagicMetadataProps = {
-        subType: subType,
-    };
-    const updatedCollection = {
-        ...collection,
-        magicMetadata: await updateMagicMetadataProps(
-            collection.magicMetadata ?? NEW_COLLECTION_MAGIC_METADATA,
-            collection.key,
-            updatedMagicMetadataProps
-        ),
-    } as Collection;
-    await updateCollectionMagicMetadata(updatedCollection);
 };
 
 export const shareCollection = async (

--- a/apps/photos/src/services/fileService.ts
+++ b/apps/photos/src/services/fileService.ts
@@ -270,7 +270,10 @@ export const updateFileMagicMetadata = async (
         updatedMagicMetadata,
     } of fileWithUpdatedMagicMetadataList) {
         const { file: encryptedMagicMetadata } =
-            await cryptoWorker.encryptMetadata(updatedMagicMetadata, file.key);
+            await cryptoWorker.encryptMetadata(
+                updatedMagicMetadata.data,
+                file.key
+            );
         reqBody.metadataList.push({
             id: file.id,
             magicMetadata: {

--- a/apps/photos/src/services/fileService.ts
+++ b/apps/photos/src/services/fileService.ts
@@ -297,7 +297,7 @@ export const updateFileMagicMetadata = async (
 
 export const updateFilePublicMagicMetadata = async (
     fileWithUpdatedPublicMagicMetadataList: FileWithUpdatedPublicMagicMetadata[]
-) => {
+): Promise<EnteFile[]> => {
     const token = getToken();
     if (!token) {
         return;

--- a/apps/photos/src/services/updateCreationTimeWithExif.ts
+++ b/apps/photos/src/services/updateCreationTimeWithExif.ts
@@ -7,7 +7,6 @@ import {
 } from 'utils/file';
 import { logError } from 'utils/sentry';
 import downloadManager from './downloadManager';
-import { updateFilePublicMagicMetadata } from './fileService';
 import { EnteFile } from 'types/file';
 
 import { getParsedExifData } from './upload/exifService';
@@ -66,13 +65,10 @@ export async function updateCreationTimeWithExif(
                     correctCreationTime &&
                     correctCreationTime !== file.metadata.creationTime
                 ) {
-                    let updatedFile = await changeFileCreationTime(
+                    const updatedFile = await changeFileCreationTime(
                         file,
                         correctCreationTime
                     );
-                    updatedFile = (
-                        await updateFilePublicMagicMetadata([updatedFile])
-                    )[0];
                     updateExistingFilePubMetadata(file, updatedFile);
                 }
             } catch (e) {

--- a/apps/photos/src/services/upload/magicMetadataService.ts
+++ b/apps/photos/src/services/upload/magicMetadataService.ts
@@ -3,12 +3,12 @@ import {
     FilePublicMagicMetadataProps,
     FilePublicMagicMetadata,
 } from 'types/magicMetadata';
-import { updateMagicMetadataProps } from 'utils/magicMetadata';
+import { updateMagicMetadata } from 'utils/magicMetadata';
 
 export async function constructPublicMagicMetadata(
     publicMagicMetadataProps: FilePublicMagicMetadataProps
 ): Promise<FilePublicMagicMetadata> {
-    const pubMagicMetadata = await updateMagicMetadataProps(
+    const pubMagicMetadata = await updateMagicMetadata(
         NEW_FILE_MAGIC_METADATA,
         null,
         publicMagicMetadataProps

--- a/apps/photos/src/types/file/index.ts
+++ b/apps/photos/src/types/file/index.ts
@@ -70,3 +70,8 @@ export interface TrashRequestItems {
     fileID: number;
     collectionID: number;
 }
+
+export interface FileWithUpdatedMagicMetadata {
+    file: EnteFile;
+    updatedMagicMetadata: FileMagicMetadata;
+}

--- a/apps/photos/src/types/file/index.ts
+++ b/apps/photos/src/types/file/index.ts
@@ -75,3 +75,8 @@ export interface FileWithUpdatedMagicMetadata {
     file: EnteFile;
     updatedMagicMetadata: FileMagicMetadata;
 }
+
+export interface FileWithUpdatedPublicMagicMetadata {
+    file: EnteFile;
+    updatedPublicMagicMetadata: FilePublicMagicMetadata;
+}

--- a/apps/photos/src/utils/collection/index.ts
+++ b/apps/photos/src/utils/collection/index.ts
@@ -33,7 +33,7 @@ import {
     SUB_TYPE,
     VISIBILITY_STATE,
 } from 'types/magicMetadata';
-import { IsArchived, updateMagicMetadataProps } from 'utils/magicMetadata';
+import { IsArchived, updateMagicMetadata } from 'utils/magicMetadata';
 import { getAlbumsURL } from 'utils/common/apiUtil';
 import bs58 from 'bs58';
 import { t } from 'i18next';
@@ -165,16 +165,12 @@ export const changeCollectionVisibility = async (
             visibility,
         };
 
-        const updatedCollection = {
-            ...collection,
-            magicMetadata: await updateMagicMetadataProps(
-                collection.magicMetadata ?? NEW_COLLECTION_MAGIC_METADATA,
-                collection.key,
-                updatedMagicMetadataProps
-            ),
-        } as Collection;
-
-        await updateCollectionMagicMetadata(updatedCollection);
+        const updatedMagicMetadata = await updateMagicMetadata(
+            collection.magicMetadata ?? NEW_COLLECTION_MAGIC_METADATA,
+            collection.key,
+            updatedMagicMetadataProps
+        );
+        await updateCollectionMagicMetadata(collection, updatedMagicMetadata);
     } catch (e) {
         logError(e, 'change file visibility failed');
         switch (e.status?.toString()) {
@@ -183,6 +179,22 @@ export const changeCollectionVisibility = async (
         }
         throw e;
     }
+};
+
+export const changeCollectionSubType = async (
+    collection: Collection,
+    subType: SUB_TYPE
+) => {
+    const updatedMagicMetadataProps: CollectionMagicMetadataProps = {
+        subType: subType,
+    };
+
+    const updatedMagicMetadata = await updateMagicMetadata(
+        collection.magicMetadata ?? NEW_COLLECTION_MAGIC_METADATA,
+        collection.key,
+        updatedMagicMetadataProps
+    );
+    await updateCollectionMagicMetadata(collection, updatedMagicMetadata);
 };
 
 export const getArchivedCollections = (collections: Collection[]) => {

--- a/apps/photos/src/utils/collection/index.ts
+++ b/apps/photos/src/utils/collection/index.ts
@@ -10,7 +10,7 @@ import {
 import { downloadFiles } from 'utils/file';
 import { getLocalFiles, getLocalHiddenFiles } from 'services/fileService';
 import { EnteFile } from 'types/file';
-import { CustomError, ServerErrorCodes } from 'utils/error';
+import { CustomError } from 'utils/error';
 import { User } from 'types/user';
 import { getData, LS_KEYS } from 'utils/storage/localStorage';
 import { logError } from 'utils/sentry';
@@ -172,11 +172,7 @@ export const changeCollectionVisibility = async (
         );
         await updateCollectionMagicMetadata(collection, updatedMagicMetadata);
     } catch (e) {
-        logError(e, 'change file visibility failed');
-        switch (e.status?.toString()) {
-            case ServerErrorCodes.FORBIDDEN:
-                throw Error(CustomError.NOT_FILE_OWNER);
-        }
+        logError(e, 'change collection visibility failed');
         throw e;
     }
 };
@@ -185,16 +181,21 @@ export const changeCollectionSubType = async (
     collection: Collection,
     subType: SUB_TYPE
 ) => {
-    const updatedMagicMetadataProps: CollectionMagicMetadataProps = {
-        subType: subType,
-    };
+    try {
+        const updatedMagicMetadataProps: CollectionMagicMetadataProps = {
+            subType: subType,
+        };
 
-    const updatedMagicMetadata = await updateMagicMetadata(
-        collection.magicMetadata ?? NEW_COLLECTION_MAGIC_METADATA,
-        collection.key,
-        updatedMagicMetadataProps
-    );
-    await updateCollectionMagicMetadata(collection, updatedMagicMetadata);
+        const updatedMagicMetadata = await updateMagicMetadata(
+            collection.magicMetadata ?? NEW_COLLECTION_MAGIC_METADATA,
+            collection.key,
+            updatedMagicMetadataProps
+        );
+        await updateCollectionMagicMetadata(collection, updatedMagicMetadata);
+    } catch (e) {
+        logError(e, 'change collection subType failed');
+        throw e;
+    }
 };
 
 export const getArchivedCollections = (collections: Collection[]) => {

--- a/apps/photos/src/utils/file/index.ts
+++ b/apps/photos/src/utils/file/index.ts
@@ -359,7 +359,7 @@ export function isExactTypeHEIC(exactType: string) {
 export async function changeFilesVisibility(
     files: EnteFile[],
     visibility: VISIBILITY_STATE
-) {
+): Promise<EnteFile[]> {
     const fileWithUpdatedMagicMetadataList: FileWithUpdatedMagicMetadata[] = [];
     for (const file of files) {
         const updatedMagicMetadataProps: FileMagicMetadataProps = {
@@ -375,8 +375,7 @@ export async function changeFilesVisibility(
             ),
         });
     }
-    await updateFileMagicMetadata(fileWithUpdatedMagicMetadataList);
-    return fileWithUpdatedMagicMetadataList;
+    return await updateFileMagicMetadata(fileWithUpdatedMagicMetadataList);
 }
 
 export async function changeFileCreationTime(

--- a/apps/photos/src/utils/file/index.ts
+++ b/apps/photos/src/utils/file/index.ts
@@ -25,7 +25,7 @@ import {
     NEW_FILE_MAGIC_METADATA,
     VISIBILITY_STATE,
 } from 'types/magicMetadata';
-import { IsArchived, updateMagicMetadataProps } from 'utils/magicMetadata';
+import { IsArchived, updateMagicMetadata } from 'utils/magicMetadata';
 
 import { addLogLine } from 'utils/logging';
 import { CustomError } from 'utils/error';
@@ -360,7 +360,7 @@ export async function changeFilesVisibility(
 
         updatedFiles.push({
             ...file,
-            magicMetadata: await updateMagicMetadataProps(
+            magicMetadata: await updateMagicMetadata(
                 file.magicMetadata ?? NEW_FILE_MAGIC_METADATA,
                 file.key,
                 updatedMagicMetadataProps
@@ -377,7 +377,7 @@ export async function changeFileCreationTime(
     const updatedPublicMagicMetadataProps: FilePublicMagicMetadataProps = {
         editedTime,
     };
-    file.pubMagicMetadata = await updateMagicMetadataProps(
+    file.pubMagicMetadata = await updateMagicMetadata(
         file.pubMagicMetadata ?? NEW_FILE_MAGIC_METADATA,
         file.key,
         updatedPublicMagicMetadataProps
@@ -390,7 +390,7 @@ export async function changeFileName(file: EnteFile, editedName: string) {
         editedName,
     };
 
-    file.pubMagicMetadata = await updateMagicMetadataProps(
+    file.pubMagicMetadata = await updateMagicMetadata(
         file.pubMagicMetadata ?? NEW_FILE_MAGIC_METADATA,
         file.key,
         updatedPublicMagicMetadataProps
@@ -403,7 +403,7 @@ export async function changeCaption(file: EnteFile, caption: string) {
         caption,
     };
 
-    file.pubMagicMetadata = await updateMagicMetadataProps(
+    file.pubMagicMetadata = await updateMagicMetadata(
         file.pubMagicMetadata ?? NEW_FILE_MAGIC_METADATA,
         file.key,
         updatedPublicMagicMetadataProps

--- a/apps/photos/src/utils/file/index.ts
+++ b/apps/photos/src/utils/file/index.ts
@@ -35,7 +35,10 @@ import { addLogLine } from 'utils/logging';
 import { CustomError } from 'utils/error';
 import { convertBytesToHumanReadable } from './size';
 import ComlinkCryptoWorker from 'utils/comlink/ComlinkCryptoWorker';
-import { updateFileMagicMetadata } from 'services/fileService';
+import {
+    updateFileMagicMetadata,
+    updateFilePublicMagicMetadata,
+} from 'services/fileService';
 
 const WAIT_TIME_IMAGE_CONVERSION = 30 * 1000;
 
@@ -379,42 +382,57 @@ export async function changeFilesVisibility(
 export async function changeFileCreationTime(
     file: EnteFile,
     editedTime: number
-) {
+): Promise<EnteFile> {
     const updatedPublicMagicMetadataProps: FilePublicMagicMetadataProps = {
         editedTime,
     };
-    file.pubMagicMetadata = await updateMagicMetadata(
-        file.pubMagicMetadata ?? NEW_FILE_MAGIC_METADATA,
-        file.key,
-        updatedPublicMagicMetadataProps
-    );
-    return file;
+    const updatedPublicMagicMetadata: FilePublicMagicMetadata =
+        await updateMagicMetadata(
+            file.pubMagicMetadata ?? NEW_FILE_MAGIC_METADATA,
+            file.key,
+            updatedPublicMagicMetadataProps
+        );
+    return await updateFilePublicMagicMetadata([
+        { file, updatedPublicMagicMetadata },
+    ])[0];
 }
 
-export async function changeFileName(file: EnteFile, editedName: string) {
+export async function changeFileName(
+    file: EnteFile,
+    editedName: string
+): Promise<EnteFile> {
     const updatedPublicMagicMetadataProps: FilePublicMagicMetadataProps = {
         editedName,
     };
 
-    file.pubMagicMetadata = await updateMagicMetadata(
-        file.pubMagicMetadata ?? NEW_FILE_MAGIC_METADATA,
-        file.key,
-        updatedPublicMagicMetadataProps
-    );
-    return file;
+    const updatedPublicMagicMetadata: FilePublicMagicMetadata =
+        await updateMagicMetadata(
+            file.pubMagicMetadata ?? NEW_FILE_MAGIC_METADATA,
+            file.key,
+            updatedPublicMagicMetadataProps
+        );
+    return await updateFilePublicMagicMetadata([
+        { file, updatedPublicMagicMetadata },
+    ])[0];
 }
 
-export async function changeCaption(file: EnteFile, caption: string) {
+export async function changeCaption(
+    file: EnteFile,
+    caption: string
+): Promise<EnteFile> {
     const updatedPublicMagicMetadataProps: FilePublicMagicMetadataProps = {
         caption,
     };
 
-    file.pubMagicMetadata = await updateMagicMetadata(
-        file.pubMagicMetadata ?? NEW_FILE_MAGIC_METADATA,
-        file.key,
-        updatedPublicMagicMetadataProps
-    );
-    return file;
+    const updatedPublicMagicMetadata: FilePublicMagicMetadata =
+        await updateMagicMetadata(
+            file.pubMagicMetadata ?? NEW_FILE_MAGIC_METADATA,
+            file.key,
+            updatedPublicMagicMetadataProps
+        );
+    return await updateFilePublicMagicMetadata([
+        { file, updatedPublicMagicMetadata },
+    ])[0];
 }
 
 export function isSharedFile(user: User, file: EnteFile) {

--- a/apps/photos/src/utils/file/index.ts
+++ b/apps/photos/src/utils/file/index.ts
@@ -391,9 +391,10 @@ export async function changeFileCreationTime(
             file.key,
             updatedPublicMagicMetadataProps
         );
-    return await updateFilePublicMagicMetadata([
+    const updateResult = await updateFilePublicMagicMetadata([
         { file, updatedPublicMagicMetadata },
-    ])[0];
+    ]);
+    return updateResult[0];
 }
 
 export async function changeFileName(
@@ -410,9 +411,10 @@ export async function changeFileName(
             file.key,
             updatedPublicMagicMetadataProps
         );
-    return await updateFilePublicMagicMetadata([
+    const updateResult = await updateFilePublicMagicMetadata([
         { file, updatedPublicMagicMetadata },
-    ])[0];
+    ]);
+    return updateResult[0];
 }
 
 export async function changeCaption(
@@ -429,9 +431,10 @@ export async function changeCaption(
             file.key,
             updatedPublicMagicMetadataProps
         );
-    return await updateFilePublicMagicMetadata([
+    const updateResult = await updateFilePublicMagicMetadata([
         { file, updatedPublicMagicMetadata },
-    ])[0];
+    ]);
+    return updateResult[0];
 }
 
 export function isSharedFile(user: User, file: EnteFile) {

--- a/apps/photos/src/utils/file/index.ts
+++ b/apps/photos/src/utils/file/index.ts
@@ -1,5 +1,9 @@
 import { SelectedState } from 'types/gallery';
-import { EnteFile, EncryptedEnteFile } from 'types/file';
+import {
+    EnteFile,
+    EncryptedEnteFile,
+    FileWithUpdatedMagicMetadata,
+} from 'types/file';
 import { decodeLivePhoto } from 'services/livePhotoService';
 import { getFileType } from 'services/typeDetectionService';
 import DownloadManager from 'services/downloadManager';
@@ -31,6 +35,7 @@ import { addLogLine } from 'utils/logging';
 import { CustomError } from 'utils/error';
 import { convertBytesToHumanReadable } from './size';
 import ComlinkCryptoWorker from 'utils/comlink/ComlinkCryptoWorker';
+import { updateFileMagicMetadata } from 'services/fileService';
 
 const WAIT_TIME_IMAGE_CONVERSION = 30 * 1000;
 
@@ -352,22 +357,23 @@ export async function changeFilesVisibility(
     files: EnteFile[],
     visibility: VISIBILITY_STATE
 ) {
-    const updatedFiles: EnteFile[] = [];
+    const fileWithUpdatedMagicMetadataList: FileWithUpdatedMagicMetadata[] = [];
     for (const file of files) {
         const updatedMagicMetadataProps: FileMagicMetadataProps = {
             visibility,
         };
 
-        updatedFiles.push({
-            ...file,
-            magicMetadata: await updateMagicMetadata(
+        fileWithUpdatedMagicMetadataList.push({
+            file,
+            updatedMagicMetadata: await updateMagicMetadata(
                 file.magicMetadata ?? NEW_FILE_MAGIC_METADATA,
                 file.key,
                 updatedMagicMetadataProps
             ),
         });
     }
-    return updatedFiles;
+    await updateFileMagicMetadata(fileWithUpdatedMagicMetadataList);
+    return fileWithUpdatedMagicMetadataList;
 }
 
 export async function changeFileCreationTime(

--- a/apps/photos/src/utils/magicMetadata/index.ts
+++ b/apps/photos/src/utils/magicMetadata/index.ts
@@ -20,7 +20,7 @@ export function IsArchived(item: Collection | EnteFile) {
     return item.magicMetadata.data.visibility === VISIBILITY_STATE.ARCHIVED;
 }
 
-export async function updateMagicMetadataProps(
+export async function updateMagicMetadata(
     originalMagicMetadata: MagicMetadataCore,
     decryptionKey: string,
     magicMetadataUpdates: Record<string, any>


### PR DESCRIPTION
## Description

- renamed `updateMagicMetadataProps` to `updateMagicMetadata` (better name as we are updating the complete  `MagicMetadata` not just the `MagicMetadataProps`)
- Updated `updateCollectionMagicMetadata` to accept `collections` and `updatedMagicMetadata` instead of a collection with updated Magic Metadata.
- Updated `updateFileMagicMetadata` and `updateFilePublicMagicMetadata` similarly to accept file and `updateFileMagicMetadata` instead of the `updatedFiles` 

## Test Plan

- [x] Tested caption change is working properly 
- [x] Tested Creation time change working properly
- [x] tested file name change working properly 
- [x] tested archive and unarchive files working properly 
- [x] tested public collect upload working properly (and uploaderName properly set)
- [x] tested change collectionSubType working properly
- [x] tested collection visibility change working properly 
