### PR TITLE
remove dedupe logic while creating new collection for add or move 

### DIFF
--- a/apps/photos/src/components/Upload/Uploader.tsx
+++ b/apps/photos/src/components/Upload/Uploader.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 
-import { createAlbum, getLatestCollections } from 'services/collectionService';
+import { getLatestCollections } from 'services/collectionService';
 import { Trans } from 'react-i18next';
 import { t } from 'i18next';
 
@@ -61,6 +61,8 @@ import {
     savePublicCollectionUploaderName,
 } from 'services/publicCollectionService';
 import { UploadTypeSelectorIntent } from 'types/gallery';
+import { getOrCreateAlbum } from 'utils/collection';
+
 const FIRST_ALBUM_NAME = 'My First Album';
 
 interface Props {
@@ -433,7 +435,7 @@ export default function Uploader(props: Props) {
                     collectionName,
                     files,
                 ] of collectionNameToFilesMap) {
-                    const collection = await createAlbum(
+                    const collection = await getOrCreateAlbum(
                         collectionName,
                         existingCollection
                     );

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -693,10 +693,7 @@ export default function Gallery() {
         const callback = async (collectionName: string) => {
             try {
                 startLoading();
-                const collection = await createAlbum(
-                    collectionName,
-                    collections
-                );
+                const collection = await createAlbum(collectionName);
                 await collectionOpsHelper(ops)(collection);
             } catch (e) {
                 logError(e, 'create and collection ops failed', { ops });

--- a/apps/photos/src/services/collectionService.ts
+++ b/apps/photos/src/services/collectionService.ts
@@ -56,7 +56,6 @@ import {
     isSharedOnlyViaLink,
     isValidMoveTarget,
     isHiddenCollection,
-    isValidReplacementAlbum,
     getNonHiddenCollections,
     changeCollectionSubType,
 } from 'utils/collection';
@@ -317,16 +316,7 @@ export const getFavItemIds = async (
     );
 };
 
-export const createAlbum = async (
-    albumName: string,
-    existingCollections: Collection[]
-) => {
-    const user: User = getData(LS_KEYS.USER);
-    for (const collection of existingCollections) {
-        if (isValidReplacementAlbum(collection, user, albumName)) {
-            return collection;
-        }
-    }
+export const createAlbum = (albumName: string) => {
     return createCollection(albumName, CollectionType.album);
 };
 

--- a/apps/photos/src/utils/collection/index.ts
+++ b/apps/photos/src/utils/collection/index.ts
@@ -1,5 +1,6 @@
 import {
     addToCollection,
+    createAlbum,
     getNonEmptyCollections,
     moveToCollection,
     removeFromCollection,
@@ -396,3 +397,16 @@ export function constructCollectionNameMap(
         ])
     );
 }
+
+export const getOrCreateAlbum = async (
+    albumName: string,
+    existingCollections: Collection[]
+) => {
+    const user: User = getData(LS_KEYS.USER);
+    for (const collection of existingCollections) {
+        if (isValidReplacementAlbum(collection, user, albumName)) {
+            return collection;
+        }
+    }
+    return createAlbum(albumName);
+};

--- a/apps/photos/src/utils/collection/index.ts
+++ b/apps/photos/src/utils/collection/index.ts
@@ -403,6 +403,9 @@ export const getOrCreateAlbum = async (
     existingCollections: Collection[]
 ) => {
     const user: User = getData(LS_KEYS.USER);
+    if (!user?.id) {
+        throw Error('user missing');
+    }
     for (const collection of existingCollections) {
         if (isValidReplacementAlbum(collection, user, albumName)) {
             return collection;


### PR DESCRIPTION
## Description
- updated the `createAlbum` function to remove the dedupe logic
- created new `getOrCreateAlbums` util to handle the upload use case


## Test Plan

- tested creating album to add flow, new album properly created
- tested creating album for upload flow, it's properly deduping and uploading to existing collection if it exists.


