### PR TITLE
Fix add to collection in search mode

### DIFF
--- a/apps/photos/src/components/Collections/index.tsx
+++ b/apps/photos/src/components/Collections/index.tsx
@@ -78,6 +78,9 @@ export default function Collections(props: Iprops) {
     );
 
     useEffect(() => {
+        if (isInSearchMode) {
+            return;
+        }
         setPhotoListHeader({
             item: (
                 <CollectionInfoWithOptions

--- a/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
+++ b/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
@@ -81,7 +81,7 @@ const SelectedFileOptions = ({
             callback: addToCollectionHelper,
             showNextModal: showCreateCollectionModal(COLLECTION_OPS_TYPE.ADD),
             title: t('ADD_TO_COLLECTION'),
-            fromCollection: activeCollection,
+            fromCollection: !isInSearchMode ? activeCollection : undefined,
         });
 
     const trashHandler = () =>
@@ -141,7 +141,7 @@ const SelectedFileOptions = ({
             callback: moveToCollectionHelper,
             showNextModal: showCreateCollectionModal(COLLECTION_OPS_TYPE.MOVE),
             title: t('MOVE_TO_COLLECTION'),
-            fromCollection: activeCollection,
+            fromCollection: !isInSearchMode ? activeCollection : undefined,
         });
     };
 
@@ -152,7 +152,7 @@ const SelectedFileOptions = ({
                 COLLECTION_OPS_TYPE.UNHIDE
             ),
             title: t('UNHIDE_TO_COLLECTION'),
-            fromCollection: activeCollection,
+            fromCollection: !isInSearchMode ? activeCollection : undefined,
         });
     };
 

--- a/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
+++ b/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
@@ -152,7 +152,6 @@ const SelectedFileOptions = ({
                 COLLECTION_OPS_TYPE.UNHIDE
             ),
             title: t('UNHIDE_TO_COLLECTION'),
-            fromCollection: !isInSearchMode ? activeCollection : undefined,
         });
     };
 

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -643,9 +643,7 @@ export default function Gallery() {
                 );
                 clearSelection();
                 await syncWithRemote(false, true);
-                if (!isInSearchMode) {
-                    setActiveCollection(collection.id);
-                }
+                setActiveCollection(collection.id);
             } catch (e) {
                 logError(e, 'collection ops failed', { ops });
                 setDialogMessage({

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -643,7 +643,9 @@ export default function Gallery() {
                 );
                 clearSelection();
                 await syncWithRemote(false, true);
-                setActiveCollection(collection.id);
+                if (!isInSearchMode) {
+                    setActiveCollection(collection.id);
+                }
             } catch (e) {
                 logError(e, 'collection ops failed', { ops });
                 setDialogMessage({


### PR DESCRIPTION
## Description
- Fix Add to Collection in search mode, not showing the collection in which the user was when he initiated the search. 
- Fix after adding to the collection in search mode, it was updating the search result header to the collection header of that collection 

## Test Plan

tested locally 
