### PR TITLE
Add hevc video to whitelisted formats

### DIFF
--- a/apps/photos/src/constants/upload.ts
+++ b/apps/photos/src/constants/upload.ts
@@ -21,6 +21,11 @@ export const WHITELISTED_FILE_FORMATS: FileTypeInfo[] = [
         exactType: 'wmv',
         mimeType: 'video/x-ms-asf',
     },
+    {
+        fileType: FILE_TYPE.VIDEO,
+        exactType: 'hevc',
+        mimeType: 'video/hevc',
+    },
 ];
 
 export const KNOWN_NON_MEDIA_FORMATS = ['xmp', 'html', 'txt'];


### PR DESCRIPTION
## Description

HEVC video type was failing, added it to whitelisted formats

## Test Plan

tested locally 
