### PR TITLE
Fix notification color

### DIFF
--- a/apps/photos/src/components/Notification.tsx
+++ b/apps/photos/src/components/Notification.tsx
@@ -4,7 +4,6 @@ import {
     Button,
     ButtonProps,
     IconButton,
-    Paper,
     Snackbar,
     Stack,
     Typography,
@@ -42,14 +41,14 @@ export default function Notification({ open, onClose, attributes }: Iprops) {
                 vertical: 'bottom',
             }}
             sx={{ backgroundColor: '#000', width: '320px' }}>
-            <Paper
-                component={Button}
+            <Button
                 color={attributes.variant}
                 onClick={handleClick}
                 sx={{
                     textAlign: 'left',
                     flex: '1',
                     padding: (theme) => theme.spacing(1.5, 2),
+                    borderRadius: '8px',
                 }}>
                 <Stack
                     flex={'1'}
@@ -89,7 +88,7 @@ export default function Notification({ open, onClose, attributes }: Iprops) {
                         </IconButton>
                     )}
                 </Stack>
-            </Paper>
+            </Button>
         </Snackbar>
     );
 }


### PR DESCRIPTION
## Description

The notification was not showing the correct colour.


### Earlier 

<img width="733" alt="image" src="https://github.com/ente-io/photos-web/assets/46242073/f270d187-ddfb-42ae-b1cd-71d2295ce6af">


### Fixed  
<img width="742" alt="image" src="https://github.com/ente-io/photos-web/assets/46242073/dc20d31e-ec08-4be8-81f9-14b41c8abbf6">


## Test Plan

tested by checking the subscription update notification 
