### PR TITLE
Allow uploads to uncategorized 

### DIFF
--- a/apps/photos/public/locales/en/translation.json
+++ b/apps/photos/public/locales/en/translation.json
@@ -528,5 +528,6 @@
     "SORT_BY": "Sort by",
     "NEWEST_FIRST": "Newest first",
     "OLDEST_FIRST": "Oldest first",
-    "CONVERSION_FAILED_NOTIFICATION_MESSAGE": "This file could not be previewed. Click here to download the original."
+    "CONVERSION_FAILED_NOTIFICATION_MESSAGE": "This file could not be previewed. Click here to download the original.",
+    "SELECT_COLLECTION":"Select album"
 }

--- a/apps/photos/src/components/Collections/CollectionSelector/index.tsx
+++ b/apps/photos/src/components/Collections/CollectionSelector/index.tsx
@@ -46,7 +46,7 @@ function CollectionSelector({
         CollectionSummary[]
     >([]);
     useEffect(() => {
-        if (!attributes) {
+        if (!attributes || !props.open) {
             return;
         }
         const main = async () => {

--- a/apps/photos/src/components/Collections/CollectionSelector/index.tsx
+++ b/apps/photos/src/components/Collections/CollectionSelector/index.tsx
@@ -1,18 +1,28 @@
-import React, { useContext, useEffect, useMemo } from 'react';
-import { Collection, CollectionSummaries } from 'types/collection';
+import React, { useContext, useEffect, useState } from 'react';
+import {
+    Collection,
+    CollectionSummaries,
+    CollectionSummary,
+} from 'types/collection';
 import DialogTitleWithCloseButton from 'components/DialogBox/TitleWithCloseButton';
-import { isUploadAllowedCollection } from 'utils/collection';
 import { AppContext } from 'pages/_app';
 import { AllCollectionDialog } from 'components/Collections/AllCollections/dialog';
 import { DialogContent } from '@mui/material';
 import { FlexWrapper } from 'components/Container';
 import CollectionSelectorCard from './CollectionCard';
 import AddCollectionButton from './AddCollectionButton';
+import { CollectionSelectorIntent } from 'types/gallery';
+import {
+    COLLECTION_SORT_ORDER,
+    CollectionSummaryType,
+} from 'constants/collection';
+import { t } from 'i18next';
+import { isSelectAllowedCollection } from 'utils/collection';
 
 export interface CollectionSelectorAttributes {
     callback: (collection: Collection) => void;
     showNextModal: () => void;
-    title: string;
+    intent: CollectionSelectorIntent;
     fromCollection?: number;
     onCancel?: () => void;
 }
@@ -31,30 +41,49 @@ function CollectionSelector({
     ...props
 }: Props) {
     const appContext = useContext(AppContext);
-    const collectionToShow = useMemo(() => {
-        const personalCollectionsOtherThanFrom = [
-            ...collectionSummaries.values(),
-        ]
-            ?.filter(
-                ({ type, id }) =>
-                    id !== attributes?.fromCollection &&
-                    isUploadAllowedCollection(type)
-            )
-            .sort((a, b) => a.name.localeCompare(b.name));
-        return personalCollectionsOtherThanFrom;
-    }, [collectionSummaries, attributes]);
 
+    const [collectionsToShow, setCollectionsToShow] = useState<
+        CollectionSummary[]
+    >([]);
     useEffect(() => {
-        if (!attributes || !props.open) {
+        if (!attributes) {
             return;
         }
-        if (collectionToShow.length === 0) {
-            props.onClose();
-            attributes.showNextModal();
-        }
-    }, [collectionToShow, attributes, props.open]);
+        const main = async () => {
+            const collectionsToShow = [...collectionSummaries.values()]
+                ?.filter(({ id, type }) => {
+                    if (id === attributes.fromCollection) {
+                        return false;
+                    } else if (
+                        attributes.intent === CollectionSelectorIntent.upload
+                    ) {
+                        return (
+                            isSelectAllowedCollection(type) ||
+                            type === CollectionSummaryType.uncategorized
+                        );
+                    } else {
+                        return isSelectAllowedCollection(type);
+                    }
+                })
+                .sort((a, b) => {
+                    return a.name.localeCompare(b.name);
+                })
+                .sort((a, b) => {
+                    return (
+                        COLLECTION_SORT_ORDER.get(a.type) -
+                        COLLECTION_SORT_ORDER.get(b.type)
+                    );
+                });
+            if (collectionsToShow.length === 0) {
+                props.onClose();
+                attributes.showNextModal();
+            }
+            setCollectionsToShow(collectionsToShow);
+        };
+        main();
+    }, [collectionSummaries, attributes]);
 
-    if (!attributes) {
+    if (!collectionsToShow?.length) {
         return <></>;
     }
 
@@ -76,14 +105,24 @@ function CollectionSelector({
             position="center"
             fullScreen={appContext.isMobile}>
             <DialogTitleWithCloseButton onClose={onUserTriggeredClose}>
-                {attributes.title}
+                {attributes.intent === CollectionSelectorIntent.upload
+                    ? t('UPLOAD_TO_COLLECTION')
+                    : attributes.intent === CollectionSelectorIntent.add
+                    ? t('ADD_TO_COLLECTION')
+                    : attributes.intent === CollectionSelectorIntent.move
+                    ? t('MOVE_TO_COLLECTION')
+                    : attributes.intent === CollectionSelectorIntent.restore
+                    ? t('RESTORE_TO_COLLECTION')
+                    : attributes.intent === CollectionSelectorIntent.unhide
+                    ? t('UNHIDE_TO_COLLECTION')
+                    : t('SELECT_COLLECTION')}
             </DialogTitleWithCloseButton>
             <DialogContent>
                 <FlexWrapper flexWrap="wrap" gap={0.5}>
                     <AddCollectionButton
                         showNextModal={attributes.showNextModal}
                     />
-                    {collectionToShow.map((collectionSummary) => (
+                    {collectionsToShow.map((collectionSummary) => (
                         <CollectionSelectorCard
                             onCollectionClick={handleCollectionClick}
                             collectionSummary={collectionSummary}

--- a/apps/photos/src/components/Upload/Uploader.tsx
+++ b/apps/photos/src/components/Upload/Uploader.tsx
@@ -8,7 +8,11 @@ import UploadProgress from './UploadProgress';
 
 import UploadStrategyChoiceModal from './UploadStrategyChoiceModal';
 import { SetCollectionNamerAttributes } from '../Collections/CollectionNamer';
-import { SetCollections, SetCollectionSelectorAttributes } from 'types/gallery';
+import {
+    CollectionSelectorIntent,
+    SetCollections,
+    SetCollectionSelectorAttributes,
+} from 'types/gallery';
 import { GalleryContext } from 'pages/gallery';
 import { AppContext } from 'pages/_app';
 import { logError } from 'utils/sentry';
@@ -687,7 +691,7 @@ export default function Uploader(props: Props) {
                 callback: uploadFilesToExistingCollection,
                 onCancel: handleCollectionSelectorCancel,
                 showNextModal,
-                title: t('UPLOAD_TO_COLLECTION'),
+                intent: CollectionSelectorIntent.upload,
             });
         } catch (e) {
             logError(e, 'handleCollectionCreationAndUpload failed');

--- a/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
+++ b/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
@@ -1,5 +1,8 @@
 import React, { useContext } from 'react';
-import { SetCollectionSelectorAttributes } from 'types/gallery';
+import {
+    CollectionSelectorIntent,
+    SetCollectionSelectorAttributes,
+} from 'types/gallery';
 import { FluidContainer } from 'components/Container';
 import { COLLECTION_OPS_TYPE } from 'utils/collection';
 import {
@@ -80,7 +83,7 @@ const SelectedFileOptions = ({
         setCollectionSelectorAttributes({
             callback: addToCollectionHelper,
             showNextModal: showCreateCollectionModal(COLLECTION_OPS_TYPE.ADD),
-            title: t('ADD_TO_COLLECTION'),
+            intent: CollectionSelectorIntent.add,
             fromCollection: !isInSearchMode ? activeCollection : undefined,
         });
 
@@ -105,7 +108,7 @@ const SelectedFileOptions = ({
             showNextModal: showCreateCollectionModal(
                 COLLECTION_OPS_TYPE.RESTORE
             ),
-            title: t('RESTORE_TO_COLLECTION'),
+            intent: CollectionSelectorIntent.restore,
         });
 
     const removeFromCollectionHandler = () => {
@@ -140,7 +143,7 @@ const SelectedFileOptions = ({
         setCollectionSelectorAttributes({
             callback: moveToCollectionHelper,
             showNextModal: showCreateCollectionModal(COLLECTION_OPS_TYPE.MOVE),
-            title: t('MOVE_TO_COLLECTION'),
+            intent: CollectionSelectorIntent.move,
             fromCollection: !isInSearchMode ? activeCollection : undefined,
         });
     };
@@ -151,7 +154,7 @@ const SelectedFileOptions = ({
             showNextModal: showCreateCollectionModal(
                 COLLECTION_OPS_TYPE.UNHIDE
             ),
-            title: t('UNHIDE_TO_COLLECTION'),
+            intent: CollectionSelectorIntent.unhide,
         });
     };
 

--- a/apps/photos/src/constants/collection.ts
+++ b/apps/photos/src/constants/collection.ts
@@ -36,17 +36,17 @@ export const COLLECTION_SHARE_DEFAULT_DEVICE_LIMIT = 4;
 
 export const COLLECTION_SORT_ORDER = new Map([
     [CollectionSummaryType.all, 0],
-    [CollectionSummaryType.favorites, 1],
-    [CollectionSummaryType.album, 2],
-    [CollectionSummaryType.folder, 2],
-    [CollectionSummaryType.incomingShare, 2],
-    [CollectionSummaryType.outgoingShare, 2],
-    [CollectionSummaryType.sharedOnlyViaLink, 2],
-    [CollectionSummaryType.archived, 2],
-    [CollectionSummaryType.archive, 3],
-    [CollectionSummaryType.trash, 4],
-    [CollectionSummaryType.uncategorized, 4],
-    [CollectionSummaryType.hidden, 4],
+    [CollectionSummaryType.uncategorized, 1],
+    [CollectionSummaryType.favorites, 2],
+    [CollectionSummaryType.album, 3],
+    [CollectionSummaryType.folder, 3],
+    [CollectionSummaryType.incomingShare, 3],
+    [CollectionSummaryType.outgoingShare, 3],
+    [CollectionSummaryType.sharedOnlyViaLink, 3],
+    [CollectionSummaryType.archived, 3],
+    [CollectionSummaryType.archive, 4],
+    [CollectionSummaryType.trash, 5],
+    [CollectionSummaryType.hidden, 5],
 ]);
 
 export const SYSTEM_COLLECTION_TYPES = new Set([
@@ -57,10 +57,11 @@ export const SYSTEM_COLLECTION_TYPES = new Set([
     CollectionSummaryType.hidden,
 ]);
 
-export const UPLOAD_NOT_ALLOWED_COLLECTION_TYPES = new Set([
+export const SELECT_NOT_ALLOWED_COLLECTION = new Set([
     CollectionSummaryType.all,
     CollectionSummaryType.archive,
     CollectionSummaryType.incomingShare,
+    CollectionSummaryType.outgoingShare,
     CollectionSummaryType.trash,
     CollectionSummaryType.uncategorized,
     CollectionSummaryType.hidden,

--- a/apps/photos/src/types/gallery/index.ts
+++ b/apps/photos/src/types/gallery/index.ts
@@ -38,3 +38,11 @@ export type GalleryContextType = {
     authenticateUser: (callback: () => void) => void;
     user: User;
 };
+
+export enum CollectionSelectorIntent {
+    upload,
+    add,
+    move,
+    restore,
+    unhide,
+}

--- a/apps/photos/src/utils/collection/index.ts
+++ b/apps/photos/src/utils/collection/index.ts
@@ -28,7 +28,7 @@ import {
     HIDE_FROM_COLLECTION_BAR_TYPES,
     OPTIONS_NOT_HAVING_COLLECTION_TYPES,
     SYSTEM_COLLECTION_TYPES,
-    UPLOAD_NOT_ALLOWED_COLLECTION_TYPES,
+    SELECT_NOT_ALLOWED_COLLECTION,
 } from 'constants/collection';
 import { getUnixTimeInMicroSecondsWithDelta } from 'utils/time';
 import { SUB_TYPE, VISIBILITY_STATE } from 'types/magicMetadata';
@@ -237,8 +237,8 @@ export const hasNonSystemCollections = (
     return false;
 };
 
-export const isUploadAllowedCollection = (type: CollectionSummaryType) => {
-    return !UPLOAD_NOT_ALLOWED_COLLECTION_TYPES.has(type);
+export const isSelectAllowedCollection = (type: CollectionSummaryType) => {
+    return !SELECT_NOT_ALLOWED_COLLECTION.has(type);
 };
 
 export const isSystemCollection = (type: CollectionSummaryType) => {


### PR DESCRIPTION
## Description

fixes #1178

- refactor `openCollectionSelectorFor` logic (by adding intent value)
- added support to upload to the uncategorised album
- show uncategorized album at the start for the upload selector screen.


### Screenshot 

<img width="584" alt="image" src="https://github.com/ente-io/photos-web/assets/46242073/3a8dc7d1-bdec-40ef-8c20-801b060bbedb">


## Test Plan

tested locally 
