### PR TITLE
Pause video on navigate

### DIFF
--- a/apps/photos/src/components/PhotoViewer/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/index.tsx
@@ -307,6 +307,10 @@ function PhotoViewer(props: Iprops) {
         photoSwipe.listen('beforeChange', () => {
             if (!photoSwipe?.currItem) return;
             const currItem = photoSwipe.currItem as EnteFile;
+            const videoTags = document.getElementsByTagName('video');
+            for (const videoTag of videoTags) {
+                videoTag.pause();
+            }
             updateFavButton(currItem);
             if (currItem.metadata.fileType !== FILE_TYPE.IMAGE) {
                 setExif({ key: currItem.src, value: null });


### PR DESCRIPTION
## Description

videos kept playing even when a user went to the next file, fixes the issue, by pausing the video on navigation trigger

## Test Plan

tested locally 
