### PR TITLE
Add option to prevent Input field caching

### DIFF
--- a/apps/photos/src/components/SingleInputForm.tsx
+++ b/apps/photos/src/components/SingleInputForm.tsx
@@ -30,6 +30,7 @@ export interface SingleInputFormProps {
     autoComplete?: string;
     blockButton?: boolean;
     hiddenLabel?: boolean;
+    disableAutoComplete?: boolean;
 }
 
 export default function SingleInputForm(props: SingleInputFormProps) {
@@ -109,6 +110,11 @@ export default function SingleInputForm(props: SingleInputFormProps) {
                         autoFocus={!props.disableAutoFocus}
                         autoComplete={props.autoComplete}
                         InputProps={{
+                            autoComplete:
+                                props.disableAutoComplete ||
+                                props.fieldType === 'password'
+                                    ? 'off'
+                                    : 'on',
                             endAdornment: props.fieldType === 'password' && (
                                 <ShowHidePassword
                                     showPassword={showPassword}

--- a/apps/photos/src/pages/recover/index.tsx
+++ b/apps/photos/src/pages/recover/index.tsx
@@ -105,6 +105,7 @@ export default function Recover() {
                     fieldType="text"
                     placeholder={t('RECOVERY_KEY_HINT')}
                     buttonText={t('RECOVER')}
+                    disableAutoComplete
                 />
                 <FormPaperFooter style={{ justifyContent: 'space-between' }}>
                     <LinkButton onClick={showNoRecoveryKeyMessage}>

--- a/apps/photos/src/pages/two-factor/recover/index.tsx
+++ b/apps/photos/src/pages/two-factor/recover/index.tsx
@@ -152,6 +152,7 @@ export default function Recover() {
                     fieldType="text"
                     placeholder={t('RECOVERY_KEY_HINT')}
                     buttonText={t('RECOVER')}
+                    disableAutoComplete
                 />
                 <FormPaperFooter style={{ justifyContent: 'space-between' }}>
                     <LinkButton onClick={() => showContactSupportDialog()}>


### PR DESCRIPTION
## Description
- add a new `disableAutoComplete` prop to `singleInputField` component, which can be passed as true to prevent caching values.

For example in the case of `recoveryKey` verify page

## Test Plan

tested locally 
