### PR TITLE
Add missed file formats to  WHITELISTED_FILE_FORMATS

### DIFF
--- a/apps/photos/src/constants/upload.ts
+++ b/apps/photos/src/constants/upload.ts
@@ -26,6 +26,22 @@ export const WHITELISTED_FILE_FORMATS: FileTypeInfo[] = [
         exactType: 'hevc',
         mimeType: 'video/hevc',
     },
+    {
+        fileType: FILE_TYPE.IMAGE,
+        exactType: 'raf',
+        mimeType: 'image/x-fuji-raf',
+    },
+    {
+        fileType: FILE_TYPE.IMAGE,
+        exactType: 'orf',
+        mimeType: 'image/x-olympus-orf',
+    },
+
+    {
+        fileType: FILE_TYPE.IMAGE,
+        exactType: 'crw',
+        mimeType: 'image/x-canon-crw',
+    },
 ];
 
 export const KNOWN_NON_MEDIA_FORMATS = ['xmp', 'html', 'txt'];


### PR DESCRIPTION
## Description

- added `CRW`, `ORF` and `RAF` to file types to missed file formats
