### PR TITLE
refactored active collection state 

### DIFF
--- a/apps/photos/src/components/Collections/AllCollections/index.tsx
+++ b/apps/photos/src/components/Collections/AllCollections/index.tsx
@@ -14,7 +14,7 @@ interface Iprops {
     open: boolean;
     onClose: () => void;
     collectionSummaries: CollectionSummary[];
-    setActiveCollection: (id?: number) => void;
+    setActiveCollectionID: (id?: number) => void;
     collectionListSortBy: COLLECTION_LIST_SORT_BY;
     setCollectionListSortBy: (v: COLLECTION_LIST_SORT_BY) => void;
 }
@@ -26,14 +26,14 @@ export default function AllCollections(props: Iprops) {
         collectionSummaries,
         open,
         onClose,
-        setActiveCollection,
+        setActiveCollectionID,
         collectionListSortBy,
         setCollectionListSortBy,
     } = props;
     const { isMobile } = useContext(AppContext);
 
     const onCollectionClick = (collectionID: number) => {
-        setActiveCollection(collectionID);
+        setActiveCollectionID(collectionID);
         onClose();
     };
 

--- a/apps/photos/src/components/Collections/CollectionListBar/CollectionCard.tsx
+++ b/apps/photos/src/components/Collections/CollectionListBar/CollectionCard.tsx
@@ -18,13 +18,13 @@ import PushPin from '@mui/icons-material/PushPin';
 
 interface Iprops {
     collectionSummary: CollectionSummary;
-    activeCollection: number;
+    activeCollectionID: number;
     onCollectionClick: (collectionID: number) => void;
     isScrolling?: boolean;
 }
 
 const CollectionListBarCard = (props: Iprops) => {
-    const { activeCollection, collectionSummary, onCollectionClick } = props;
+    const { activeCollectionID, collectionSummary, onCollectionClick } = props;
 
     return (
         <Box>
@@ -37,7 +37,7 @@ const CollectionListBarCard = (props: Iprops) => {
                 <CollectionCardText collectionName={collectionSummary.name} />
                 <CollectionCardIcon collectionType={collectionSummary.type} />
             </CollectionCard>
-            {activeCollection === collectionSummary.id && <ActiveIndicator />}
+            {activeCollectionID === collectionSummary.id && <ActiveIndicator />}
         </Box>
     );
 };

--- a/apps/photos/src/components/Collections/CollectionListBar/index.tsx
+++ b/apps/photos/src/components/Collections/CollectionListBar/index.tsx
@@ -24,8 +24,8 @@ import useWindowSize from 'hooks/useWindowSize';
 import ScrollButton from './ScrollButton';
 
 interface IProps {
-    activeCollection?: number;
-    setActiveCollection: (id?: number) => void;
+    activeCollectionID?: number;
+    setActiveCollectionID: (id?: number) => void;
     collectionSummaries: CollectionSummary[];
     showAllCollections: () => void;
     collectionListSortBy: COLLECTION_LIST_SORT_BY;
@@ -34,16 +34,16 @@ interface IProps {
 
 interface ItemData {
     collectionSummaries: CollectionSummary[];
-    activeCollection?: number;
+    activeCollectionID?: number;
     onCollectionClick: (id?: number) => void;
 }
 
 const CollectionListBarCardWidth = 94;
 
 const createItemData = memoize(
-    (collectionSummaries, activeCollection, onCollectionClick) => ({
+    (collectionSummaries, activeCollectionID, onCollectionClick) => ({
         collectionSummaries,
-        activeCollection,
+        activeCollectionID,
         onCollectionClick,
     })
 );
@@ -55,7 +55,7 @@ const CollectionCardContainer = React.memo(
         style,
         isScrolling,
     }: ListChildComponentProps<ItemData>) => {
-        const { collectionSummaries, activeCollection, onCollectionClick } =
+        const { collectionSummaries, activeCollectionID, onCollectionClick } =
             data;
 
         const collectionSummary = collectionSummaries[index];
@@ -64,7 +64,7 @@ const CollectionCardContainer = React.memo(
             <div style={style}>
                 <CollectionListBarCard
                     key={collectionSummary.id}
-                    activeCollection={activeCollection}
+                    activeCollectionID={activeCollectionID}
                     isScrolling={isScrolling}
                     collectionSummary={collectionSummary}
                     onCollectionClick={onCollectionClick}
@@ -81,8 +81,8 @@ const getItemKey = (index: number, data: ItemData) => {
 
 const CollectionListBar = (props: IProps) => {
     const {
-        activeCollection,
-        setActiveCollection,
+        activeCollectionID,
+        setActiveCollectionID,
         collectionSummaries,
         showAllCollections,
     } = props;
@@ -108,18 +108,18 @@ const CollectionListBar = (props: IProps) => {
         }
         // scroll the active collection into view
         const activeCollectionIndex = collectionSummaries.findIndex(
-            (item) => item.id === activeCollection
+            (item) => item.id === activeCollectionID
         );
         collectionListRef.current.scrollToItem(activeCollectionIndex, 'smart');
-    }, [activeCollection]);
+    }, [activeCollectionID]);
 
     const onCollectionClick = (collectionID?: number) => {
-        setActiveCollection(collectionID ?? ALL_SECTION);
+        setActiveCollectionID(collectionID ?? ALL_SECTION);
     };
 
     const itemData = createItemData(
         collectionSummaries,
-        activeCollection,
+        activeCollectionID,
         onCollectionClick
     );
 

--- a/apps/photos/src/components/Collections/index.tsx
+++ b/apps/photos/src/components/Collections/index.tsx
@@ -1,6 +1,6 @@
 import { Collection, CollectionSummaries } from 'types/collection';
 import CollectionListBar from 'components/Collections/CollectionListBar';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import AllCollections from 'components/Collections/AllCollections';
 import CollectionInfoWithOptions from 'components/Collections/CollectionInfoWithOptions';
 import { ALL_SECTION, COLLECTION_LIST_SORT_BY } from 'constants/collection';
@@ -17,7 +17,7 @@ import { sortCollectionSummaries } from 'services/collectionService';
 import { LS_KEYS } from 'utils/storage/localStorage';
 
 interface Iprops {
-    collections: Collection[];
+    activeCollection: Collection;
     activeCollectionID?: number;
     setActiveCollectionID: (id?: number) => void;
     isInSearchMode: boolean;
@@ -28,7 +28,7 @@ interface Iprops {
 
 export default function Collections(props: Iprops) {
     const {
-        collections,
+        activeCollection,
         isInSearchMode,
         activeCollectionID,
         setActiveCollectionID,
@@ -46,8 +46,6 @@ export default function Collections(props: Iprops) {
             LS_KEYS.COLLECTION_SORT_BY,
             COLLECTION_LIST_SORT_BY.UPDATION_TIME_DESCENDING
         );
-    const collectionsMap = useRef<Map<number, Collection>>(new Map());
-    const activeCollection = useRef<Collection>(null);
 
     const shouldBeHidden = useMemo(
         () =>
@@ -56,17 +54,6 @@ export default function Collections(props: Iprops) {
                 activeCollectionID === ALL_SECTION),
         [isInSearchMode, collectionSummaries, activeCollectionID]
     );
-
-    useEffect(() => {
-        collectionsMap.current = new Map(
-            props.collections.map((collection) => [collection.id, collection])
-        );
-    }, [collections]);
-
-    useEffect(() => {
-        activeCollection.current =
-            collectionsMap.current.get(activeCollectionID);
-    }, [activeCollectionID, collections]);
 
     const sortedCollectionSummaries = useMemo(
         () =>
@@ -87,7 +74,7 @@ export default function Collections(props: Iprops) {
                     collectionSummary={collectionSummaries.get(
                         activeCollectionID
                     )}
-                    activeCollection={activeCollection.current}
+                    activeCollection={activeCollection}
                     setCollectionNamerAttributes={setCollectionNamerAttributes}
                     redirectToAll={() => setActiveCollectionID(ALL_SECTION)}
                     showCollectionShareModal={() =>
@@ -111,8 +98,8 @@ export default function Collections(props: Iprops) {
     return (
         <>
             <CollectionListBar
-                activeCollection={activeCollectionID}
-                setActiveCollection={setActiveCollectionID}
+                activeCollectionID={activeCollectionID}
+                setActiveCollectionID={setActiveCollectionID}
                 collectionSummaries={sortedCollectionSummaries.filter((x) =>
                     shouldBeShownOnCollectionBar(x.type)
                 )}
@@ -127,7 +114,7 @@ export default function Collections(props: Iprops) {
                 collectionSummaries={sortedCollectionSummaries.filter(
                     (x) => !isSystemCollection(x.type)
                 )}
-                setActiveCollection={setActiveCollectionID}
+                setActiveCollectionID={setActiveCollectionID}
                 setCollectionListSortBy={setCollectionListSortBy}
                 collectionListSortBy={collectionListSortBy}
             />
@@ -136,7 +123,7 @@ export default function Collections(props: Iprops) {
                 collectionSummary={collectionSummaries.get(activeCollectionID)}
                 open={collectionShareModalView}
                 onClose={closeCollectionShare}
-                collection={activeCollection.current}
+                collection={activeCollection}
             />
         </>
     );

--- a/apps/photos/src/components/PhotoFrame.tsx
+++ b/apps/photos/src/components/PhotoFrame.tsx
@@ -44,7 +44,7 @@ interface Props {
     selected: SelectedState;
     deletedFileIds?: Set<number>;
     setDeletedFileIds?: (value: Set<number>) => void;
-    activeCollection: number;
+    activeCollectionID: number;
     enableDownload?: boolean;
     fileToCollectionsMap: Map<number, number[]>;
     collectionNameMap: Map<number, string>;
@@ -59,7 +59,7 @@ const PhotoFrame = ({
     selected,
     deletedFileIds,
     setDeletedFileIds,
-    activeCollection,
+    activeCollectionID,
     enableDownload,
     fileToCollectionsMap,
     collectionNameMap,
@@ -258,7 +258,7 @@ const PhotoFrame = ({
                 }
             }
             setSelected((selected) => {
-                if (selected.collectionID !== activeCollection) {
+                if (selected.collectionID !== activeCollectionID) {
                     selected = { ownCount: 0, count: 0, collectionID: 0 };
                 }
 
@@ -288,7 +288,7 @@ const PhotoFrame = ({
                 return {
                     ...selected,
                     [id]: checked,
-                    collectionID: activeCollection,
+                    collectionID: activeCollectionID,
                     ...handleAllCounterChange(),
                 };
             });
@@ -345,7 +345,8 @@ const PhotoFrame = ({
                 index
             )}
             selected={
-                selected.collectionID === activeCollection && selected[item.id]
+                selected.collectionID === activeCollectionID &&
+                selected[item.id]
             }
             selectOnClick={selected.count > 0}
             onHover={onHoverOver(index)}
@@ -355,7 +356,7 @@ const PhotoFrame = ({
                 (index >= rangeStart && index <= currentHover) ||
                 (index >= currentHover && index <= rangeStart)
             }
-            activeCollection={activeCollection}
+            activeCollectionID={activeCollectionID}
             showPlaceholder={isScrolling}
         />
     );
@@ -513,7 +514,7 @@ const PhotoFrame = ({
                         height={height}
                         getThumbnail={getThumbnail}
                         displayFiles={displayFiles}
-                        activeCollection={activeCollection}
+                        activeCollectionID={activeCollectionID}
                         showAppDownloadBanner={showAppDownloadBanner}
                     />
                 )}
@@ -527,8 +528,8 @@ const PhotoFrame = ({
                 favItemIds={favItemIds}
                 deletedFileIds={deletedFileIds}
                 setDeletedFileIds={setDeletedFileIds}
-                isTrashCollection={activeCollection === TRASH_SECTION}
-                isHiddenCollection={activeCollection === HIDDEN_SECTION}
+                isTrashCollection={activeCollectionID === TRASH_SECTION}
+                isHiddenCollection={activeCollectionID === HIDDEN_SECTION}
                 enableDownload={enableDownload}
                 isSourceLoaded={isSourceLoaded}
                 conversionFailed={conversionFailed}

--- a/apps/photos/src/components/PhotoList.tsx
+++ b/apps/photos/src/components/PhotoList.tsx
@@ -176,7 +176,7 @@ interface Props {
         index: number,
         isScrolling?: boolean
     ) => JSX.Element;
-    activeCollection: number;
+    activeCollectionID: number;
 }
 
 interface ItemData {
@@ -233,7 +233,7 @@ export function PhotoList({
     displayFiles,
     showAppDownloadBanner,
     getThumbnail,
-    activeCollection,
+    activeCollectionID,
 }: Props) {
     const galleryContext = useContext(GalleryContext);
     const publicCollectionGalleryContext = useContext(
@@ -801,7 +801,7 @@ export function PhotoList({
 
     return (
         <List
-            key={`${activeCollection}`}
+            key={`${activeCollectionID}`}
             itemData={itemData}
             ref={listRef}
             itemSize={getItemSize(timeStampList)}

--- a/apps/photos/src/components/PhotoViewer/FileInfo/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/FileInfo/index.tsx
@@ -178,7 +178,7 @@ export function FileInfo({
         return <></>;
     }
     const onCollectionChipClick = (collectionID) => {
-        galleryContext.setActiveCollection(collectionID);
+        galleryContext.setActiveCollectionID(collectionID);
         galleryContext.setIsInSearchMode(false);
         closePhotoViewer();
     };

--- a/apps/photos/src/components/Search/SearchBar/index.tsx
+++ b/apps/photos/src/components/Search/SearchBar/index.tsx
@@ -10,7 +10,6 @@ import { UpdateSearch } from 'types/search';
 interface Props {
     updateSearch: UpdateSearch;
     collections: Collection[];
-    setActiveCollection: (id: number) => void;
     files: EnteFile[];
     isInSearchMode: boolean;
     setIsInSearchMode: (v: boolean) => void;

--- a/apps/photos/src/components/Search/SearchBar/searchInput/index.tsx
+++ b/apps/photos/src/components/Search/SearchBar/searchInput/index.tsx
@@ -34,7 +34,6 @@ interface Iprops {
     setIsOpen: (value: boolean) => void;
     files: EnteFile[];
     collections: Collection[];
-    setActiveCollection: (id: number) => void;
 }
 
 const createComponents = memoize((Option, ValueContainer, Menu) => ({

--- a/apps/photos/src/components/Sidebar/ShortcutSection.tsx
+++ b/apps/photos/src/components/Sidebar/ShortcutSection.tsx
@@ -42,23 +42,23 @@ export default function ShortcutSection({
     }, []);
 
     const openUncategorizedSection = () => {
-        galleryContext.setActiveCollection(uncategorizedCollectionId);
+        galleryContext.setActiveCollectionID(uncategorizedCollectionId);
         closeSidebar();
     };
 
     const openTrashSection = () => {
-        galleryContext.setActiveCollection(TRASH_SECTION);
+        galleryContext.setActiveCollectionID(TRASH_SECTION);
         closeSidebar();
     };
 
     const openArchiveSection = () => {
-        galleryContext.setActiveCollection(ARCHIVE_SECTION);
+        galleryContext.setActiveCollectionID(ARCHIVE_SECTION);
         closeSidebar();
     };
 
     const openHiddenSection = () => {
         galleryContext.authenticateUser(() => {
-            galleryContext.setActiveCollection(HIDDEN_SECTION);
+            galleryContext.setActiveCollectionID(HIDDEN_SECTION);
             closeSidebar();
         });
     };

--- a/apps/photos/src/components/pages/gallery/Navbar.tsx
+++ b/apps/photos/src/components/pages/gallery/Navbar.tsx
@@ -15,7 +15,6 @@ interface Iprops {
     setIsInSearchMode: (v: boolean) => void;
     collections: Collection[];
     files: EnteFile[];
-    setActiveCollection: (id: number) => void;
     updateSearch: UpdateSearch;
 }
 export function GalleryNavbar({
@@ -24,7 +23,6 @@ export function GalleryNavbar({
     isInSearchMode,
     collections,
     files,
-    setActiveCollection,
     updateSearch,
     setIsInSearchMode,
 }: Iprops) {
@@ -36,7 +34,6 @@ export function GalleryNavbar({
                 setIsInSearchMode={setIsInSearchMode}
                 collections={collections}
                 files={files}
-                setActiveCollection={setActiveCollection}
                 updateSearch={updateSearch}
             />
             {!isInSearchMode && <UploadButton openUploader={openUploader} />}

--- a/apps/photos/src/components/pages/gallery/PreviewCard.tsx
+++ b/apps/photos/src/components/pages/gallery/PreviewCard.tsx
@@ -34,7 +34,7 @@ interface IProps {
     isRangeSelectActive: boolean;
     selectOnClick: boolean;
     isInsSelectRange: boolean;
-    activeCollection: number;
+    activeCollectionID: number;
     showPlaceholder: boolean;
 }
 
@@ -388,7 +388,7 @@ export default function PreviewCard(props: IProps) {
                     </p>
                 </FileAndCollectionNameOverlay>
             )}
-            {props?.activeCollection === TRASH_SECTION && file.isTrashed && (
+            {props?.activeCollectionID === TRASH_SECTION && file.isTrashed && (
                 <FileAndCollectionNameOverlay>
                     <p>{formatDateRelative(file.deleteBy / 1000)}</p>
                 </FileAndCollectionNameOverlay>

--- a/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
+++ b/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
@@ -42,7 +42,7 @@ interface Props {
     count: number;
     ownCount: number;
     clearSelection: () => void;
-    activeCollection: number;
+    activeCollectionID: number;
     isFavoriteCollection: boolean;
     isUncategorizedCollection: boolean;
     isIncomingSharedCollection: boolean;
@@ -59,7 +59,7 @@ const SelectedFileOptions = ({
     count,
     ownCount,
     clearSelection,
-    activeCollection,
+    activeCollectionID,
     isFavoriteCollection,
     isUncategorizedCollection,
     isIncomingSharedCollection,
@@ -71,7 +71,7 @@ const SelectedFileOptions = ({
             callback: handleCollectionOps(COLLECTION_OPS_TYPE.ADD),
             showNextModal: showCreateCollectionModal(COLLECTION_OPS_TYPE.ADD),
             intent: CollectionSelectorIntent.add,
-            fromCollection: !isInSearchMode ? activeCollection : undefined,
+            fromCollection: !isInSearchMode ? activeCollectionID : undefined,
         });
 
     const trashHandler = () =>
@@ -139,7 +139,7 @@ const SelectedFileOptions = ({
             callback: handleCollectionOps(COLLECTION_OPS_TYPE.MOVE),
             showNextModal: showCreateCollectionModal(COLLECTION_OPS_TYPE.MOVE),
             intent: CollectionSelectorIntent.move,
-            fromCollection: !isInSearchMode ? activeCollection : undefined,
+            fromCollection: !isInSearchMode ? activeCollectionID : undefined,
         });
     };
 
@@ -198,7 +198,7 @@ const SelectedFileOptions = ({
                             </IconButton>
                         </Tooltip>
                     </>
-                ) : activeCollection === TRASH_SECTION ? (
+                ) : activeCollectionID === TRASH_SECTION ? (
                     <>
                         <Tooltip title={t('RESTORE')}>
                             <IconButton onClick={restoreHandler}>
@@ -237,7 +237,7 @@ const SelectedFileOptions = ({
                             <DownloadIcon />
                         </IconButton>
                     </Tooltip>
-                ) : activeCollection === HIDDEN_SECTION ? (
+                ) : activeCollectionID === HIDDEN_SECTION ? (
                     <>
                         <Tooltip title={t('UNHIDE')}>
                             <IconButton onClick={unhideToCollection}>
@@ -276,7 +276,7 @@ const SelectedFileOptions = ({
                                 <AddIcon />
                             </IconButton>
                         </Tooltip>
-                        {activeCollection === ARCHIVE_SECTION && (
+                        {activeCollectionID === ARCHIVE_SECTION && (
                             <Tooltip title={t('UNARCHIVE')}>
                                 <IconButton
                                     onClick={handleFileOps(
@@ -286,7 +286,7 @@ const SelectedFileOptions = ({
                                 </IconButton>
                             </Tooltip>
                         )}
-                        {activeCollection === ALL_SECTION && (
+                        {activeCollectionID === ALL_SECTION && (
                             <Tooltip title={t('ARCHIVE')}>
                                 <IconButton
                                     onClick={handleFileOps(
@@ -296,8 +296,8 @@ const SelectedFileOptions = ({
                                 </IconButton>
                             </Tooltip>
                         )}
-                        {activeCollection !== ALL_SECTION &&
-                            activeCollection !== ARCHIVE_SECTION &&
+                        {activeCollectionID !== ALL_SECTION &&
+                            activeCollectionID !== ARCHIVE_SECTION &&
                             !isFavoriteCollection && (
                                 <>
                                     <Tooltip title={t('MOVE')}>

--- a/apps/photos/src/pages/deduplicate/index.tsx
+++ b/apps/photos/src/pages/deduplicate/index.tsx
@@ -194,7 +194,7 @@ export default function Deduplicate() {
                     syncWithRemote={syncWithRemote}
                     setSelected={setSelected}
                     selected={selected}
-                    activeCollection={ALL_SECTION}
+                    activeCollectionID={ALL_SECTION}
                     fileToCollectionsMap={fileToCollectionsMap}
                     collectionNameMap={collectionNameMap}
                 />

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -136,7 +136,7 @@ const defaultGalleryContext: GalleryContextType = {
     thumbs: new Map(),
     files: new Map(),
     showPlanSelectorModal: () => null,
-    setActiveCollection: () => null,
+    setActiveCollectionID: () => null,
     syncWithRemote: () => null,
     setBlockingLoad: () => null,
     setIsInSearchMode: () => null,
@@ -224,7 +224,8 @@ export default function Gallery() {
     const [userIDToEmailMap, setUserIDToEmailMap] =
         useState<Map<number, string>>(null);
     const [emailList, setEmailList] = useState<string[]>(null);
-    const [activeCollection, setActiveCollection] = useState<number>(undefined);
+    const [activeCollectionID, setActiveCollectionID] =
+        useState<number>(undefined);
     const [fixCreationTimeView, setFixCreationTimeView] = useState(false);
     const [fixCreationTimeAttributes, setFixCreationTimeAttributes] =
         useState<FixCreationTimeAttributes>(null);
@@ -275,7 +276,7 @@ export default function Gallery() {
             if (!valid) {
                 return;
             }
-            setActiveCollection(ALL_SECTION);
+            setActiveCollectionID(ALL_SECTION);
             setIsFirstLoad(isFirstLogin());
             setIsFirstFetch(true);
             if (justSignedUp()) {
@@ -350,22 +351,22 @@ export default function Gallery() {
     }, [fixCreationTimeAttributes]);
 
     useEffect(() => {
-        if (typeof activeCollection === 'undefined') {
+        if (typeof activeCollectionID === 'undefined') {
             return;
         }
         let collectionURL = '';
-        if (activeCollection !== ALL_SECTION) {
+        if (activeCollectionID !== ALL_SECTION) {
             collectionURL += '?collection=';
-            if (activeCollection === ARCHIVE_SECTION) {
+            if (activeCollectionID === ARCHIVE_SECTION) {
                 collectionURL += t('ARCHIVE_SECTION_NAME');
-            } else if (activeCollection === TRASH_SECTION) {
+            } else if (activeCollectionID === TRASH_SECTION) {
                 collectionURL += t('TRASH');
-            } else if (activeCollection === DUMMY_UNCATEGORIZED_SECTION) {
+            } else if (activeCollectionID === DUMMY_UNCATEGORIZED_SECTION) {
                 collectionURL += t('UNCATEGORIZED');
-            } else if (activeCollection === HIDDEN_SECTION) {
+            } else if (activeCollectionID === HIDDEN_SECTION) {
                 collectionURL += t('HIDDEN');
             } else {
-                collectionURL += activeCollection;
+                collectionURL += activeCollectionID;
             }
         }
         const href = `/gallery${collectionURL}`;
@@ -376,7 +377,7 @@ export default function Gallery() {
         };
 
         delayRouteChange();
-    }, [activeCollection]);
+    }, [activeCollectionID]);
 
     useEffect(() => {
         const key = getKey(SESSION_KEYS.ENCRYPTION_KEY);
@@ -403,6 +404,12 @@ export default function Gallery() {
         }
     }, [isInSearchMode, searchResultSummary]);
 
+    const activeCollection = useMemo(() => {
+        return collections?.find(
+            (collection) => collection.id === activeCollectionID
+        );
+    }, [collections, activeCollectionID]);
+
     const filteredData = useMemoSingleThreaded((): EnteFile[] => {
         if (
             !files ||
@@ -414,24 +421,24 @@ export default function Gallery() {
             return;
         }
 
-        if (activeCollection === HIDDEN_SECTION && !isInSearchMode) {
+        if (activeCollectionID === HIDDEN_SECTION && !isInSearchMode) {
             return getUniqueFiles([
                 ...hiddenFiles,
                 ...files.filter((file) => hiddenFileIds?.has(file.id)),
             ]);
         }
 
-        if (activeCollection === TRASH_SECTION && !isInSearchMode) {
+        if (activeCollectionID === TRASH_SECTION && !isInSearchMode) {
             return getUniqueFiles([
                 ...trashedFiles,
                 ...files.filter((file) => deletedFileIds?.has(file.id)),
             ]);
         }
         let sortAsc = false;
-        if (activeCollection > 0) {
+        if (activeCollectionID > 0) {
             // find matching collection in collections
             for (const collection of collections) {
-                if (collection.id === activeCollection) {
+                if (collection.id === activeCollectionID) {
                     sortAsc = collection?.pubMagicMetadata?.data?.asc ?? false;
                     break;
                 }
@@ -496,7 +503,7 @@ export default function Gallery() {
 
                 // archived collections files can only be seen in their respective collection
                 if (archivedCollections.has(item.collectionID)) {
-                    if (activeCollection === item.collectionID) {
+                    if (activeCollectionID === item.collectionID) {
                         return true;
                     } else {
                         return false;
@@ -506,8 +513,8 @@ export default function Gallery() {
                 // Archived files can only be seen in archive section or their respective collection
                 if (isArchivedFile(item)) {
                     if (
-                        activeCollection === ARCHIVE_SECTION ||
-                        activeCollection === item.collectionID
+                        activeCollectionID === ARCHIVE_SECTION ||
+                        activeCollectionID === item.collectionID
                     ) {
                         return true;
                     } else {
@@ -516,12 +523,12 @@ export default function Gallery() {
                 }
 
                 // ALL SECTION - show all files
-                if (activeCollection === ALL_SECTION) {
+                if (activeCollectionID === ALL_SECTION) {
                     return true;
                 }
 
                 // COLLECTION SECTION - show files in the active collection
-                if (activeCollection === item.collectionID) {
+                if (activeCollectionID === item.collectionID) {
                     return true;
                 } else {
                     return false;
@@ -536,7 +543,7 @@ export default function Gallery() {
         deletedFileIds,
         hiddenFileIds,
         search,
-        activeCollection,
+        activeCollectionID,
         archivedCollections,
     ]);
 
@@ -658,7 +665,7 @@ export default function Gallery() {
         const selected = {
             ownCount: 0,
             count: 0,
-            collectionID: activeCollection,
+            collectionID: activeCollectionID,
         };
 
         filteredData.forEach((item) => {
@@ -698,7 +705,7 @@ export default function Gallery() {
 
                 clearSelection();
                 await syncWithRemote(false, true);
-                setActiveCollection(collection.id);
+                setActiveCollectionID(collection.id);
             } catch (e) {
                 logError(e, 'collection ops failed', { ops });
                 setDialogMessage({
@@ -773,7 +780,7 @@ export default function Gallery() {
 
     const updateSearch: UpdateSearch = (newSearch, summary) => {
         if (newSearch?.collection) {
-            setActiveCollection(newSearch?.collection);
+            setActiveCollectionID(newSearch?.collection);
         } else {
             setSearch(newSearch);
         }
@@ -810,7 +817,7 @@ export default function Gallery() {
             value={{
                 ...defaultGalleryContext,
                 showPlanSelectorModal,
-                setActiveCollection,
+                setActiveCollectionID,
                 syncWithRemote,
                 setBlockingLoad,
                 setIsInSearchMode,
@@ -871,15 +878,14 @@ export default function Gallery() {
                     isInSearchMode={isInSearchMode}
                     collections={collections}
                     files={files}
-                    setActiveCollection={setActiveCollection}
                     updateSearch={updateSearch}
                 />
 
                 <Collections
-                    collections={collections}
+                    activeCollection={activeCollection}
                     isInSearchMode={isInSearchMode}
-                    activeCollectionID={activeCollection}
-                    setActiveCollectionID={setActiveCollection}
+                    activeCollectionID={activeCollectionID}
+                    setActiveCollectionID={setActiveCollectionID}
                     collectionSummaries={collectionSummaries}
                     setCollectionNamerAttributes={setCollectionNamerAttributes}
                     setPhotoListHeader={setPhotoListHeader}
@@ -928,7 +934,7 @@ export default function Gallery() {
                 !isFirstLoad &&
                 !files?.length &&
                 !hiddenFiles?.length &&
-                activeCollection === ALL_SECTION ? (
+                activeCollectionID === ALL_SECTION ? (
                     <GalleryEmptyState openUploader={openUploader} />
                 ) : (
                     <PhotoFrame
@@ -939,7 +945,7 @@ export default function Gallery() {
                         selected={selected}
                         deletedFileIds={deletedFileIds}
                         setDeletedFileIds={setDeletedFileIds}
-                        activeCollection={activeCollection}
+                        activeCollectionID={activeCollectionID}
                         enableDownload={true}
                         fileToCollectionsMap={fileToCollectionsMap}
                         collectionNameMap={collectionNameMap}
@@ -949,7 +955,7 @@ export default function Gallery() {
                     />
                 )}
                 {selected.count > 0 &&
-                    selected.collectionID === activeCollection && (
+                    selected.collectionID === activeCollectionID && (
                         <SelectedFileOptions
                             handleCollectionOps={collectionOpsHelper}
                             handleFileOps={fileOpsHelper}
@@ -962,25 +968,25 @@ export default function Gallery() {
                             count={selected.count}
                             ownCount={selected.ownCount}
                             clearSelection={clearSelection}
-                            activeCollection={activeCollection}
+                            activeCollectionID={activeCollectionID}
                             selectedCollection={getSelectedCollection(
                                 selected.collectionID,
                                 collections
                             )}
                             isFavoriteCollection={
-                                collectionSummaries.get(activeCollection)
+                                collectionSummaries.get(activeCollectionID)
                                     ?.type === CollectionSummaryType.favorites
                             }
                             isUncategorizedCollection={
-                                collectionSummaries.get(activeCollection)
+                                collectionSummaries.get(activeCollectionID)
                                     ?.type ===
                                 CollectionSummaryType.uncategorized
                             }
                             isIncomingSharedCollection={
-                                collectionSummaries.get(activeCollection)
+                                collectionSummaries.get(activeCollectionID)
                                     ?.type ===
                                     CollectionSummaryType.incomingShareCollaborator ||
-                                collectionSummaries.get(activeCollection)
+                                collectionSummaries.get(activeCollectionID)
                                     ?.type ===
                                     CollectionSummaryType.incomingShareViewer
                             }

--- a/apps/photos/src/pages/shared-albums/index.tsx
+++ b/apps/photos/src/pages/shared-albums/index.tsx
@@ -453,7 +453,7 @@ export default function PublicCollectionGallery() {
                     syncWithRemote={syncWithRemote}
                     setSelected={() => null}
                     selected={{ count: 0, collectionID: null, ownCount: 0 }}
-                    activeCollection={ALL_SECTION}
+                    activeCollectionID={ALL_SECTION}
                     enableDownload={downloadEnabled}
                     fileToCollectionsMap={null}
                     collectionNameMap={null}

--- a/apps/photos/src/types/gallery/index.ts
+++ b/apps/photos/src/types/gallery/index.ts
@@ -30,7 +30,7 @@ export type GalleryContextType = {
     thumbs: Map<number, string>;
     files: Map<number, MergedSourceURL>;
     showPlanSelectorModal: () => void;
-    setActiveCollection: (collection: number) => void;
+    setActiveCollectionID: (collectionID: number) => void;
     syncWithRemote: (force?: boolean, silent?: boolean) => Promise<void>;
     setBlockingLoad: (value: boolean) => void;
     setIsInSearchMode: (value: boolean) => void;


### PR DESCRIPTION
## Description

renamed the existing `activeCollection` state that refers to the active collection id to `activeCollectionID` 

and moved the `activeCollection` state from collections component to gallery 

## Test Plan

tested locally 
