### PR TITLE
Fix select all issue

### DIFF
--- a/apps/photos/src/components/PhotoFrame.tsx
+++ b/apps/photos/src/components/PhotoFrame.tsx
@@ -49,6 +49,7 @@ interface Props {
     fileToCollectionsMap: Map<number, number[]>;
     collectionNameMap: Map<number, string>;
     showAppDownloadBanner?: boolean;
+    setIsPhotoSwipeOpen?: (value: boolean) => void;
 }
 
 const PhotoFrame = ({
@@ -64,6 +65,7 @@ const PhotoFrame = ({
     fileToCollectionsMap,
     collectionNameMap,
     showAppDownloadBanner,
+    setIsPhotoSwipeOpen,
 }: Props) => {
     const [open, setOpen] = useState(false);
     const [currentIndex, setCurrentIndex] = useState<number>(0);
@@ -148,8 +150,10 @@ const PhotoFrame = ({
                 PHOTOSWIPE_HASH_SUFFIX
             );
             if (shouldPhotoSwipeBeOpened) {
+                setIsPhotoSwipeOpen?.(true);
                 setOpen(true);
             } else {
+                setIsPhotoSwipeOpen?.(false);
                 setOpen(false);
             }
         });
@@ -240,11 +244,13 @@ const PhotoFrame = ({
     const handleClose = (needUpdate) => {
         setOpen(false);
         needUpdate && syncWithRemote();
+        setIsPhotoSwipeOpen?.(false);
     };
 
     const onThumbnailClick = (index: number) => () => {
         setCurrentIndex(index);
         setOpen(true);
+        setIsPhotoSwipeOpen?.(true);
     };
 
     const handleSelect =

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -550,6 +550,13 @@ export default function Gallery() {
     ]);
 
     const selectAll = (e: KeyboardEvent) => {
+        // ignore ctrl/cmd + a if the user is typing in a text field
+        if (
+            e.target instanceof HTMLInputElement ||
+            e.target instanceof HTMLTextAreaElement
+        ) {
+            return;
+        }
         // if any of the modals are open, don't select all
         if (
             sidebarView ||
@@ -666,13 +673,6 @@ export default function Gallery() {
 
     const setupSelectAllKeyBoardShortcutHandler = () => {
         const handleKeyUp = (e: KeyboardEvent) => {
-            // ignore ctrl/cmd + a if the user is typing in a text field
-            if (
-                e.target instanceof HTMLInputElement ||
-                e.target instanceof HTMLTextAreaElement
-            ) {
-                return;
-            }
             switch (e.key) {
                 case 'Escape':
                     selectAllKeyBoardShortcutHandlerRef.current.clearSelection();

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -549,7 +549,7 @@ export default function Gallery() {
         archivedCollections,
     ]);
 
-    const selectAll = () => {
+    const selectAll = (e: KeyboardEvent) => {
         // if any of the modals are open, don't select all
         if (
             sidebarView ||
@@ -566,6 +566,7 @@ export default function Gallery() {
         ) {
             return;
         }
+        e.preventDefault();
         const selected = {
             ownCount: 0,
             count: 0,
@@ -678,8 +679,9 @@ export default function Gallery() {
                     break;
                 case 'a':
                     if (e.ctrlKey || e.metaKey) {
-                        e.preventDefault();
-                        selectAllKeyBoardShortcutHandlerRef.current.selectAll();
+                        selectAllKeyBoardShortcutHandlerRef.current.selectAll(
+                            e
+                        );
                     }
                     break;
             }

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -591,16 +591,19 @@ export default function Gallery() {
     };
 
     const clearSelection = () => {
+        if (!selected?.count) {
+            return;
+        }
         setSelected({ ownCount: 0, count: 0, collectionID: 0 });
     };
 
-    const selectAllKeyBoardShortcutHandlerRef = useRef({
+    const keyboardShortcutHandlerRef = useRef({
         selectAll,
         clearSelection,
     });
 
     useEffect(() => {
-        selectAllKeyBoardShortcutHandlerRef.current = {
+        keyboardShortcutHandlerRef.current = {
             selectAll,
             clearSelection,
         };
@@ -675,13 +678,11 @@ export default function Gallery() {
         const handleKeyUp = (e: KeyboardEvent) => {
             switch (e.key) {
                 case 'Escape':
-                    selectAllKeyBoardShortcutHandlerRef.current.clearSelection();
+                    keyboardShortcutHandlerRef.current.clearSelection();
                     break;
                 case 'a':
                     if (e.ctrlKey || e.metaKey) {
-                        selectAllKeyBoardShortcutHandlerRef.current.selectAll(
-                            e
-                        );
+                        keyboardShortcutHandlerRef.current.selectAll(e);
                     }
                     break;
             }


### PR DESCRIPTION
## Description

### Fixed issue 
- don't trigger select all, if any modals are open
- don't trigger select all, if the user is typing in an input field 

### Added new shortcut 
- Added keyboard shortcut to clear selection with `esc` 

## Test Plan

tested locally 
