### PR TITLE
fix drag and drop upload issue

### DIFF
--- a/apps/photos/src/components/Upload/Uploader.tsx
+++ b/apps/photos/src/components/Upload/Uploader.tsx
@@ -682,10 +682,15 @@ export default function Uploader(props: Props) {
             if (isFirstUpload && !importSuggestion.rootFolderName) {
                 importSuggestion.rootFolderName = FIRST_ALBUM_NAME;
             }
-            if (isDragAndDrop.current && props.activeCollection) {
+            if (isDragAndDrop.current) {
                 isDragAndDrop.current = false;
-                uploadFilesToExistingCollection(props.activeCollection);
-                return;
+                if (
+                    props.activeCollection &&
+                    props.activeCollection.owner.id === galleryContext.user?.id
+                ) {
+                    uploadFilesToExistingCollection(props.activeCollection);
+                    return;
+                }
             }
             let showNextModal = () => {};
             if (importSuggestion.hasNestedFolders) {


### PR DESCRIPTION
## Description

Drag and drop to active album was failing for case where the album was not owned by the user

Added is-self-owned album check before uploading to active album

## Test Plan

tested locally 
