### PR TITLE
Fix export rename issue

### DIFF
--- a/apps/photos/src/services/export/index.ts
+++ b/apps/photos/src/services/export/index.ts
@@ -1131,10 +1131,6 @@ class ExportService {
         return this.electronAPIs.checkExistsAndCreateDir(path);
     };
 
-    deleteFolder = (path: string, deleteFiles?: boolean) => {
-        return this.electronAPIs.deleteFolder(path, deleteFiles);
-    };
-
     exportFolderExists = (exportFolder: string) => {
         return exportFolder && this.exists(exportFolder);
     };

--- a/apps/photos/src/services/export/index.ts
+++ b/apps/photos/src/services/export/index.ts
@@ -1054,6 +1054,7 @@ class ExportService {
         file: EnteFile
     ): Promise<void> {
         try {
+            const fileUID = getExportRecordFileUID(file);
             let fileStream = await downloadManager.downloadFile(file);
             const fileType = getFileExtension(file.metadata.title);
             if (
@@ -1074,6 +1075,7 @@ class ExportService {
             if (file.metadata.fileType === FILE_TYPE.LIVE_PHOTO) {
                 await this.exportLivePhoto(
                     exportDir,
+                    fileUID,
                     collectionExportPath,
                     fileStream,
                     file
@@ -1083,7 +1085,6 @@ class ExportService {
                     collectionExportPath,
                     file.metadata.title
                 );
-                const fileUID = getExportRecordFileUID(file);
                 await this.addFileExportedRecord(
                     exportDir,
                     fileUID,
@@ -1101,10 +1102,7 @@ class ExportService {
                         fileStream
                     );
                 } catch (e) {
-                    await this.removeFileExportedRecord(
-                        exportDir,
-                        getExportRecordFileUID(file)
-                    );
+                    await this.removeFileExportedRecord(exportDir, fileUID);
                     throw e;
                 }
             }
@@ -1116,6 +1114,7 @@ class ExportService {
 
     private async exportLivePhoto(
         exportDir: string,
+        fileUID: string,
         collectionExportPath: string,
         fileStream: ReadableStream<any>,
         file: EnteFile
@@ -1134,7 +1133,6 @@ class ExportService {
             imageExportName,
             videoExportName
         );
-        const fileUID = getExportRecordFileUID(file);
         await this.addFileExportedRecord(
             exportDir,
             fileUID,
@@ -1172,10 +1170,7 @@ class ExportService {
                 throw e;
             }
         } catch (e) {
-            await this.removeFileExportedRecord(
-                exportDir,
-                getExportRecordFileUID(file)
-            );
+            await this.removeFileExportedRecord(exportDir, fileUID);
             throw e;
         }
     }

--- a/apps/photos/src/services/export/index.ts
+++ b/apps/photos/src/services/export/index.ts
@@ -789,24 +789,28 @@ class ExportService {
                             addLogLine(
                                 `moving image file ${imageExportPath} to trash folder`
                             );
-                            await this.electronAPIs.moveFile(
-                                imageExportPath,
-                                getTrashedFileExportPath(
-                                    exportDir,
-                                    imageExportPath
-                                )
-                            );
+                            if (this.exists(imageExportPath)) {
+                                await this.electronAPIs.moveFile(
+                                    imageExportPath,
+                                    getTrashedFileExportPath(
+                                        exportDir,
+                                        imageExportPath
+                                    )
+                                );
+                            }
 
                             const imageMetadataFileExportPath =
                                 getMetadataFileExportPath(imageExportPath);
 
-                            await this.electronAPIs.moveFile(
-                                imageMetadataFileExportPath,
-                                getTrashedFileExportPath(
-                                    exportDir,
-                                    imageMetadataFileExportPath
-                                )
-                            );
+                            if (this.exists(imageMetadataFileExportPath)) {
+                                await this.electronAPIs.moveFile(
+                                    imageMetadataFileExportPath,
+                                    getTrashedFileExportPath(
+                                        exportDir,
+                                        imageMetadataFileExportPath
+                                    )
+                                );
+                            }
 
                             const videoExportPath = getFileExportPath(
                                 collectionExportPath,
@@ -815,22 +819,26 @@ class ExportService {
                             addLogLine(
                                 `moving video file ${videoExportPath} to trash folder`
                             );
-                            await this.electronAPIs.moveFile(
-                                videoExportPath,
-                                getTrashedFileExportPath(
-                                    exportDir,
-                                    videoExportPath
-                                )
-                            );
+                            if (this.exists(videoExportPath)) {
+                                await this.electronAPIs.moveFile(
+                                    videoExportPath,
+                                    getTrashedFileExportPath(
+                                        exportDir,
+                                        videoExportPath
+                                    )
+                                );
+                            }
                             const videoMetadataFileExportPath =
                                 getMetadataFileExportPath(videoExportPath);
-                            await this.electronAPIs.moveFile(
-                                videoMetadataFileExportPath,
-                                getTrashedFileExportPath(
-                                    exportDir,
-                                    videoMetadataFileExportPath
-                                )
-                            );
+                            if (this.exists(videoMetadataFileExportPath)) {
+                                await this.electronAPIs.moveFile(
+                                    videoMetadataFileExportPath,
+                                    getTrashedFileExportPath(
+                                        exportDir,
+                                        videoMetadataFileExportPath
+                                    )
+                                );
+                            }
                         } else {
                             const fileExportPath = getFileExportPath(
                                 collectionExportPath,
@@ -843,19 +851,23 @@ class ExportService {
                             addLogLine(
                                 `moving file ${fileExportPath} to ${trashedFilePath} trash folder`
                             );
-                            await this.electronAPIs.moveFile(
-                                fileExportPath,
-                                trashedFilePath
-                            );
+                            if (this.exists(fileExportPath)) {
+                                await this.electronAPIs.moveFile(
+                                    fileExportPath,
+                                    trashedFilePath
+                                );
+                            }
                             const metadataFileExportPath =
                                 getMetadataFileExportPath(fileExportPath);
-                            await this.electronAPIs.moveFile(
-                                metadataFileExportPath,
-                                getTrashedFileExportPath(
-                                    exportDir,
-                                    metadataFileExportPath
-                                )
-                            );
+                            if (this.exists(metadataFileExportPath)) {
+                                await this.electronAPIs.moveFile(
+                                    metadataFileExportPath,
+                                    getTrashedFileExportPath(
+                                        exportDir,
+                                        metadataFileExportPath
+                                    )
+                                );
+                            }
                         }
                     } catch (e) {
                         await this.addFileExportedRecord(

--- a/apps/photos/src/services/export/index.ts
+++ b/apps/photos/src/services/export/index.ts
@@ -1001,7 +1001,7 @@ class ExportService {
         }
     }
 
-    async getExportRecord(folder: string): Promise<ExportRecord> {
+    async getExportRecord(folder: string, retry = true): Promise<ExportRecord> {
         try {
             this.verifyExportFolderExists(folder);
             const exportRecordJSONPath = `${folder}/${EXPORT_RECORD_FILE_NAME}`;
@@ -1017,9 +1017,12 @@ class ExportService {
                 throw Error(CustomError.EXPORT_RECORD_JSON_PARSING_FAILED);
             }
         } catch (e) {
-            if (e.message === CustomError.EXPORT_RECORD_JSON_PARSING_FAILED) {
+            if (
+                e.message === CustomError.EXPORT_RECORD_JSON_PARSING_FAILED &&
+                retry
+            ) {
                 await sleep(1000);
-                return await this.getExportRecord(folder);
+                return await this.getExportRecord(folder, false);
             }
             if (e.message !== CustomError.EXPORT_FOLDER_DOES_NOT_EXIST) {
                 logError(e, 'export Record JSON parsing failed');

--- a/apps/photos/src/services/export/index.ts
+++ b/apps/photos/src/services/export/index.ts
@@ -1123,6 +1123,10 @@ class ExportService {
         return this.electronAPIs.checkExistsAndCreateDir(path);
     };
 
+    deleteFolder = (path: string, deleteFiles?: boolean) => {
+        return this.electronAPIs.deleteFolder(path, deleteFiles);
+    };
+
     exportFolderExists = (exportFolder: string) => {
         return exportFolder && this.exists(exportFolder);
     };

--- a/apps/photos/src/services/export/index.ts
+++ b/apps/photos/src/services/export/index.ts
@@ -1101,21 +1101,11 @@ class ExportService {
                     fileExportName,
                     file
                 );
-                try {
-                    await this.saveMediaFile(
-                        collectionExportPath,
-                        fileExportName,
-                        fileStream
-                    );
-                } catch (e) {
-                    await this.deleteExportedFile(
-                        getFileMetadataExportPath(
-                            collectionExportPath,
-                            fileExportName
-                        )
-                    );
-                    throw e;
-                }
+                await this.saveMediaFile(
+                    collectionExportPath,
+                    fileExportName,
+                    fileStream
+                );
                 return fileExportName;
             }
         } catch (e) {
@@ -1141,39 +1131,23 @@ class ExportService {
             imageExportName,
             file
         );
-        try {
-            await this.saveMediaFile(
-                collectionExportPath,
-                imageExportName,
-                imageStream
-            );
-        } catch (e) {
-            await this.deleteExportedFile(
-                getFileMetadataExportPath(collectionExportPath, imageExportName)
-            );
-            throw e;
-        }
+        await this.saveMediaFile(
+            collectionExportPath,
+            imageExportName,
+            imageStream
+        );
 
         const videoStream = generateStreamFromArrayBuffer(livePhoto.video);
         const videoExportName = getUniqueFileExportName(
             collectionExportPath,
             livePhoto.videoNameTitle
         );
-        try {
-            await this.saveMetadataFile(
-                collectionExportPath,
-                videoExportName,
-                file
-            );
-        } catch (e) {
-            await this.deleteExportedFile(
-                getFileExportPath(collectionExportPath, imageExportName)
-            );
-            await this.deleteExportedFile(
-                getFileMetadataExportPath(collectionExportPath, imageExportName)
-            );
-            throw e;
-        }
+
+        await this.saveMetadataFile(
+            collectionExportPath,
+            videoExportName,
+            file
+        );
         try {
             await this.saveMediaFile(
                 collectionExportPath,
@@ -1183,12 +1157,6 @@ class ExportService {
         } catch (e) {
             await this.deleteExportedFile(
                 getFileExportPath(collectionExportPath, imageExportName)
-            );
-            await this.deleteExportedFile(
-                getFileMetadataExportPath(collectionExportPath, imageExportName)
-            );
-            await this.deleteExportedFile(
-                getFileMetadataExportPath(collectionExportPath, videoExportName)
             );
             throw e;
         }

--- a/apps/photos/src/services/export/index.ts
+++ b/apps/photos/src/services/export/index.ts
@@ -1,4 +1,4 @@
-import { runningInBrowser } from 'utils/common';
+import { runningInBrowser, sleep } from 'utils/common';
 import {
     getUnExportedFiles,
     getGoogleLikeMetadataFile,
@@ -961,8 +961,16 @@ class ExportService {
             const recordFile = await this.electronAPIs.readTextFile(
                 exportRecordJSONPath
             );
-            return JSON.parse(recordFile);
+            try {
+                return JSON.parse(recordFile);
+            } catch (e) {
+                throw Error(CustomError.EXPORT_RECORD_JSON_PARSING_FAILED);
+            }
         } catch (e) {
+            if (e.message === CustomError.EXPORT_RECORD_JSON_PARSING_FAILED) {
+                await sleep(1000);
+                return await this.getExportRecord(folder);
+            }
             if (e.message !== CustomError.EXPORT_FOLDER_DOES_NOT_EXIST) {
                 logError(e, 'export Record JSON parsing failed');
             }

--- a/apps/photos/src/services/export/index.ts
+++ b/apps/photos/src/services/export/index.ts
@@ -669,6 +669,9 @@ class ExportService {
                     await this.electronAPIs.checkExistsAndCreateDir(
                         collectionExportPath
                     );
+                    await this.electronAPIs.checkExistsAndCreateDir(
+                        getMetadataFolderExportPath(collectionExportPath)
+                    );
                     const fileExportName = await this.downloadAndSave(
                         collectionExportPath,
                         file

--- a/apps/photos/src/services/export/migration.ts
+++ b/apps/photos/src/services/export/migration.ts
@@ -12,7 +12,13 @@ import {
 import { EnteFile } from 'types/file';
 import { User } from 'types/user';
 import { getNonEmptyPersonalCollections } from 'utils/collection';
-import { getExportRecordFileUID, getLivePhotoExportName } from 'utils/export';
+import {
+    getCollectionExportPath,
+    getCollectionIDFromFileUID,
+    getExportRecordFileUID,
+    getLivePhotoExportName,
+    getMetadataFolderExportPath,
+} from 'utils/export';
 import {
     getIDBasedSortedFiles,
     getPersonalFiles,
@@ -83,6 +89,14 @@ export async function migrateExport(
                 version: 4,
             });
             addLogLine('migration to version 4 complete');
+        }
+        if (exportRecord.version === 4) {
+            addLogLine('migrating export to version 5');
+            await migrationV4ToV5(exportDir, exportRecord as ExportRecord);
+            exportRecord = await exportService.updateExportRecord(exportDir, {
+                version: 5,
+            });
+            addLogLine('migration to version 5 complete');
         }
         addLogLine(`Record at latest version`);
     } catch (e) {
@@ -174,6 +188,10 @@ async function migrationV3ToV4(exportDir: string, exportRecord: ExportRecord) {
     };
 
     await exportService.updateExportRecord(exportDir, updatedExportRecord);
+}
+
+async function migrationV4ToV5(exportDir: string, exportRecord: ExportRecord) {
+    await removeCollectionExportMissingMetadataFolder(exportDir, exportRecord);
 }
 
 /*
@@ -403,5 +421,68 @@ async function addCollectionExportedRecordV1(
     } catch (e) {
         logError(e, 'addCollectionExportedRecord failed');
         throw e;
+    }
+}
+
+async function removeCollectionExportMissingMetadataFolder(
+    exportDir: string,
+    exportRecord: ExportRecord
+) {
+    if (!exportRecord?.collectionExportNames) {
+        return;
+    }
+
+    const properlyExportedCollections = Object.entries(
+        exportRecord.collectionExportNames
+    )
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        .filter(([_, collectionExportName]) =>
+            exportService.exists(
+                getMetadataFolderExportPath(
+                    getCollectionExportPath(exportDir, collectionExportName)
+                )
+            )
+        );
+
+    const properlyExportedCollectionIDs = properlyExportedCollections.map(
+        ([collectionID]) => Number(collectionID)
+    );
+
+    const missingMetadataFolderCollection = Object.entries(
+        exportRecord.collectionExportNames
+    ).filter(
+        ([collectionID]) =>
+            !properlyExportedCollectionIDs.includes(Number(collectionID))
+    );
+
+    const properlyExportedFiles = Object.entries(
+        exportRecord.fileExportNames
+    ).filter(([fileUID]) =>
+        properlyExportedCollectionIDs.includes(
+            getCollectionIDFromFileUID(fileUID)
+        )
+    );
+
+    const updatedExportRecord: ExportRecord = {
+        ...exportRecord,
+        collectionExportNames: Object.fromEntries(
+            properlyExportedCollections
+        ) as CollectionExportNames,
+        fileExportNames: Object.fromEntries(
+            properlyExportedFiles
+        ) as FileExportNames,
+    };
+    await exportService.updateExportRecord(exportDir, updatedExportRecord);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for (const [_, collectionExportName] of missingMetadataFolderCollection) {
+        const collectionExportPath = getCollectionExportPath(
+            exportDir,
+            collectionExportName
+        );
+        await exportService.deleteFolder(
+            getMetadataFolderExportPath(collectionExportPath),
+            true
+        );
     }
 }

--- a/apps/photos/src/services/export/migration.ts
+++ b/apps/photos/src/services/export/migration.ts
@@ -445,21 +445,14 @@ async function removeCollectionExportMissingMetadataFolder(
         );
 
     const properlyExportedCollectionIDs = properlyExportedCollections.map(
-        ([collectionID]) => Number(collectionID)
-    );
-
-    const missingMetadataFolderCollection = Object.entries(
-        exportRecord.collectionExportNames
-    ).filter(
-        ([collectionID]) =>
-            !properlyExportedCollectionIDs.includes(Number(collectionID))
+        ([collectionID]) => collectionID
     );
 
     const properlyExportedFiles = Object.entries(
         exportRecord.fileExportNames
     ).filter(([fileUID]) =>
         properlyExportedCollectionIDs.includes(
-            getCollectionIDFromFileUID(fileUID)
+            getCollectionIDFromFileUID(fileUID).toString()
         )
     );
 
@@ -473,16 +466,4 @@ async function removeCollectionExportMissingMetadataFolder(
         ) as FileExportNames,
     };
     await exportService.updateExportRecord(exportDir, updatedExportRecord);
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for (const [_, collectionExportName] of missingMetadataFolderCollection) {
-        const collectionExportPath = getCollectionExportPath(
-            exportDir,
-            collectionExportName
-        );
-        await exportService.deleteFolder(
-            getMetadataFolderExportPath(collectionExportPath),
-            true
-        );
-    }
 }

--- a/apps/photos/src/types/electron/index.ts
+++ b/apps/photos/src/types/electron/index.ts
@@ -90,6 +90,6 @@ export interface ElectronAPIs {
     registerForegroundEventListener: (onForeground: () => void) => void;
     openDirectory: (dirPath: string) => Promise<void>;
     moveFile: (oldPath: string, newPath: string) => Promise<void>;
-    deleteFolder: (path: string, deleteFiles?: boolean) => Promise<void>;
+    deleteFolder: (path: string) => Promise<void>;
     rename: (oldPath: string, newPath: string) => Promise<void>;
 }

--- a/apps/photos/src/types/electron/index.ts
+++ b/apps/photos/src/types/electron/index.ts
@@ -90,6 +90,6 @@ export interface ElectronAPIs {
     registerForegroundEventListener: (onForeground: () => void) => void;
     openDirectory: (dirPath: string) => Promise<void>;
     moveFile: (oldPath: string, newPath: string) => Promise<void>;
-    deleteFolder: (path: string) => Promise<void>;
+    deleteFolder: (path: string, deleteFiles?: boolean) => Promise<void>;
     rename: (oldPath: string, newPath: string) => Promise<void>;
 }

--- a/apps/photos/src/types/electron/index.ts
+++ b/apps/photos/src/types/electron/index.ts
@@ -91,5 +91,6 @@ export interface ElectronAPIs {
     openDirectory: (dirPath: string) => Promise<void>;
     moveFile: (oldPath: string, newPath: string) => Promise<void>;
     deleteFolder: (path: string) => Promise<void>;
+    deleteFile: (path: string) => void;
     rename: (oldPath: string, newPath: string) => Promise<void>;
 }

--- a/apps/photos/src/utils/error/index.ts
+++ b/apps/photos/src/utils/error/index.ts
@@ -70,6 +70,7 @@ export const CustomError = {
     UNSUPPORTED_RAW_FORMAT: 'unsupported raw format',
     NON_PREVIEWABLE_FILE: 'non previewable file',
     PROCESSING_FAILED: 'processing failed',
+    EXPORT_RECORD_JSON_PARSING_FAILED: 'export record json parsing failed',
 };
 
 export function parseUploadErrorCodes(error) {


### PR DESCRIPTION
## Description
- Changed flow to first update export record update and then attempt export and add rollback logic if export fails 
- Fixed the issue of the metadata folder not being existing for export. 
- Added auto-retry logic to getExportRecord function, which waits for 1 sec and retries to get the export record file, to avoid temporary file read issues. 
## Test Plan

- tested export sync operations 
- tested migration 
