### PR TITLE
remove club by capture time option [dedupe screen] 

### DIFF
--- a/apps/photos/src/components/pages/dedupe/SelectedFileOptions.tsx
+++ b/apps/photos/src/components/pages/dedupe/SelectedFileOptions.tsx
@@ -1,8 +1,7 @@
 import { FluidContainer } from 'components/Container';
 import { SelectionBar } from '../../Navbar/SelectionBar';
-import React, { useContext } from 'react';
-import { Box, IconButton, styled, Tooltip } from '@mui/material';
-import { DeduplicateContext } from 'pages/deduplicate';
+import { useContext } from 'react';
+import { Box, IconButton, Tooltip } from '@mui/material';
 import { AppContext } from 'pages/_app';
 import CloseIcon from '@mui/icons-material/Close';
 import BackButton from '@mui/icons-material/ArrowBackOutlined';
@@ -10,20 +9,6 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { getTrashFilesMessage } from 'utils/ui';
 import { t } from 'i18next';
 import { formatNumber } from 'utils/number/format';
-
-const VerticalLine = styled('div')`
-    position: absolute;
-    width: 1px;
-    top: 0;
-    bottom: 0;
-    background: #303030;
-`;
-
-const CheckboxText = styled('div')`
-    margin-left: 0.5em;
-    font-size: 16px;
-    margin-right: 0.8em;
-`;
 
 interface IProps {
     deleteFileHelper: () => void;
@@ -38,7 +23,6 @@ export default function DeduplicateOptions({
     count,
     clearSelection,
 }: IProps) {
-    const deduplicateContext = useContext(DeduplicateContext);
     const { setDialogMessage } = useContext(AppContext);
 
     const trashHandler = () =>
@@ -60,24 +44,6 @@ export default function DeduplicateOptions({
                     {formatNumber(count)} {t('SELECTED')}
                 </Box>
             </FluidContainer>
-            <input
-                type="checkbox"
-                style={{
-                    width: '1em',
-                    height: '1em',
-                }}
-                value={
-                    deduplicateContext.clubSameTimeFilesOnly ? 'true' : 'false'
-                }
-                onChange={() => {
-                    deduplicateContext.setClubSameTimeFilesOnly(
-                        !deduplicateContext.clubSameTimeFilesOnly
-                    );
-                }}></input>
-            <CheckboxText>{t('CLUB_BY_CAPTURE_TIME')}</CheckboxText>
-            <div>
-                <VerticalLine />
-            </div>
             <Tooltip title={t('DELETE')}>
                 <IconButton onClick={trashHandler}>
                     <DeleteIcon />


### PR DESCRIPTION
## Description

Have for now, just removed the option to toggle club by capture time
will remove and cleanup the code later on.

### screenshot 

earlier 
<img width="731" alt="image" src="https://github.com/ente-io/photos-web/assets/46242073/12155e3f-2410-45b0-9900-324ca2f7ab60">

updated
<img width="712" alt="image" src="https://github.com/ente-io/photos-web/assets/46242073/7ad59d4f-ebba-4422-a05c-87cdafbd2138">


## Test Plan
tested locally 
