### PR TITLE
Remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'monthly'
-    open-pull-requests-limit: 5
-      


### PR DESCRIPTION
## Description

Testing breaking changes in packages and updating them...
When the current version is working, it seems like a waste of energy, 

So, I will remove `dependabot` config... and go back to updating packages only when we are facing issue with the package 