### PR TITLE
Fixed date time parsing

### DIFF
--- a/apps/photos/src/services/updateCreationTimeWithExif.ts
+++ b/apps/photos/src/services/updateCreationTimeWithExif.ts
@@ -12,7 +12,7 @@ import { EnteFile } from 'types/file';
 import { getParsedExifData } from './upload/exifService';
 import { getFileType } from 'services/typeDetectionService';
 import { FILE_TYPE } from 'constants/file';
-import { getUnixTimeInMicroSeconds } from 'utils/time';
+import { validateAndGetCreationUnixTimeInMicroSeconds } from 'utils/time';
 
 const EXIF_TIME_TAGS = [
     'DateTimeOriginal',
@@ -38,7 +38,7 @@ export async function updateCreationTimeWithExif(
             try {
                 let correctCreationTime: number;
                 if (fixOption === FIX_OPTIONS.CUSTOM_TIME) {
-                    correctCreationTime = getUnixTimeInMicroSeconds(customTime);
+                    correctCreationTime = customTime.getTime() * 1000;
                 } else {
                     if (file.metadata.fileType !== FILE_TYPE.IMAGE) {
                         continue;
@@ -53,17 +53,21 @@ export async function updateCreationTimeWithExif(
                         EXIF_TIME_TAGS
                     );
                     if (fixOption === FIX_OPTIONS.DATE_TIME_ORIGINAL) {
-                        correctCreationTime = getUnixTimeInMicroSeconds(
-                            exifData?.DateTimeOriginal ?? exifData?.DateCreated
-                        );
+                        correctCreationTime =
+                            validateAndGetCreationUnixTimeInMicroSeconds(
+                                exifData?.DateTimeOriginal ??
+                                    exifData?.DateCreated
+                            );
                     } else if (fixOption === FIX_OPTIONS.DATE_TIME_DIGITIZED) {
-                        correctCreationTime = getUnixTimeInMicroSeconds(
-                            exifData?.CreateDate
-                        );
+                        correctCreationTime =
+                            validateAndGetCreationUnixTimeInMicroSeconds(
+                                exifData?.CreateDate
+                            );
                     } else if (fixOption === FIX_OPTIONS.METADATA_DATE) {
-                        correctCreationTime = getUnixTimeInMicroSeconds(
-                            exifData?.MetadataDate
-                        );
+                        correctCreationTime =
+                            validateAndGetCreationUnixTimeInMicroSeconds(
+                                exifData?.MetadataDate
+                            );
                     } else {
                         throw new Error('Invalid fix option');
                     }

--- a/apps/photos/src/services/upload/exifService.ts
+++ b/apps/photos/src/services/upload/exifService.ts
@@ -4,7 +4,7 @@ import exifr from 'exifr';
 import piexif from 'piexifjs';
 import { FileTypeInfo } from 'types/upload';
 import { logError } from 'utils/sentry';
-import { getUnixTimeInMicroSeconds } from 'utils/time';
+import { validateAndGetCreationUnixTimeInMicroSeconds } from 'utils/time';
 import { CustomError } from 'utils/error';
 
 const EXIFR_UNSUPPORTED_FILE_FORMAT_MESSAGE = 'Unknown file format';
@@ -305,7 +305,7 @@ export function getEXIFTime(exifData: ParsedEXIFData): number {
     if (!dateTime) {
         return null;
     }
-    return getUnixTimeInMicroSeconds(dateTime);
+    return validateAndGetCreationUnixTimeInMicroSeconds(dateTime);
 }
 
 export async function updateFileCreationDateInEXIF(

--- a/apps/photos/src/services/upload/metadataService.ts
+++ b/apps/photos/src/services/upload/metadataService.ts
@@ -14,7 +14,7 @@ import { NULL_EXTRACTED_METADATA, NULL_LOCATION } from 'constants/upload';
 import { getVideoMetadata } from './videoMetadataService';
 import {
     parseDateFromFusedDateString,
-    getUnixTimeInMicroSeconds,
+    validateAndGetCreationUnixTimeInMicroSeconds,
     tryToParseDateTime,
 } from 'utils/time';
 import { getFileHash } from './hashService';
@@ -208,7 +208,7 @@ export function extractDateFromFileName(filename: string): number {
         if (!parsedDate) {
             parsedDate = tryToParseDateTime(filename);
         }
-        return getUnixTimeInMicroSeconds(parsedDate);
+        return validateAndGetCreationUnixTimeInMicroSeconds(parsedDate);
     } catch (e) {
         logError(e, 'failed to extract date From FileName ');
         return null;

--- a/apps/photos/src/utils/ffmpeg/index.ts
+++ b/apps/photos/src/utils/ffmpeg/index.ts
@@ -1,6 +1,6 @@
 import { NULL_LOCATION } from 'constants/upload';
 import { ParsedExtractedMetadata } from 'types/upload';
-import { getUnixTimeInMicroSeconds } from 'utils/time';
+import { validateAndGetCreationUnixTimeInMicroSeconds } from 'utils/time';
 
 enum MetadataTags {
     CREATION_TIME = 'creation_time',
@@ -59,7 +59,9 @@ function parseAppleISOLocation(isoLocation: string) {
 function parseCreationTime(creationTime: string) {
     let dateTime = null;
     if (creationTime) {
-        dateTime = getUnixTimeInMicroSeconds(new Date(creationTime));
+        dateTime = validateAndGetCreationUnixTimeInMicroSeconds(
+            new Date(creationTime)
+        );
     }
     return dateTime;
 }

--- a/apps/photos/src/utils/time/index.ts
+++ b/apps/photos/src/utils/time/index.ts
@@ -31,13 +31,15 @@ export function getUnixTimeInMicroSecondsWithDelta(delta: TimeDelta): number {
     return currentDate.getTime() * 1000;
 }
 
-export function getUnixTimeInMicroSeconds(dateTime: Date) {
+export function validateAndGetCreationUnixTimeInMicroSeconds(dateTime: Date) {
     if (!dateTime || isNaN(dateTime.getTime())) {
         return null;
     }
     const unixTime = dateTime.getTime() * 1000;
     //ignoring dateTimeString = "0000:00:00 00:00:00"
     if (unixTime === Date.UTC(0, 0, 0, 0, 0, 0, 0) || unixTime === 0) {
+        return null;
+    } else if (unixTime > Date.now() * 1000) {
         return null;
     } else {
         return unixTime;

--- a/apps/photos/src/utils/time/index.ts
+++ b/apps/photos/src/utils/time/index.ts
@@ -167,7 +167,7 @@ function getDateFromComponents(dateComponent: DateComponent<number>) {
 
 function hasTimeValues(dateComponent: DateComponent<number>) {
     const { hour, minute, second } = dateComponent;
-    return hour && minute && second;
+    return !isNaN(hour) && !isNaN(minute) && !isNaN(second);
 }
 
 function removeTimeValues(


### PR DESCRIPTION
## Description

During Date time parsing, the dimension in the filename got parsed as a time value. (in filename -`2019-07-16-111843_1366x768_scrot.png`)

- Added better date validation  
- Refactored code 
- renamed `getUnixTimeInMicroSeconds` to `validateAndGetCreationUnixTimeInMicroSeconds` and added extra validation that creation time can't be in future 

## Test Plan

tested with user-given files 


