### PR TITLE
reposition convert button

### DIFF
--- a/apps/photos/src/components/PhotoViewer/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/index.tsx
@@ -43,7 +43,6 @@ import { getParsedExifData } from 'services/upload/exifService';
 import { getFileType } from 'services/typeDetectionService';
 import { ConversionFailedNotification } from './styledComponents/ConversionFailedNotification';
 import { GalleryContext } from 'pages/gallery';
-import { ConvertBtnContainer } from './styledComponents/ConvertBtn';
 import downloadManager from 'services/downloadManager';
 import publicCollectionDownloadManager from 'services/publicCollectionDownloadManager';
 import CircularProgressWithLabel from './styledComponents/CircularProgressWithLabel';
@@ -51,6 +50,7 @@ import EnteSpinner from 'components/EnteSpinner';
 import AlbumOutlined from '@mui/icons-material/AlbumOutlined';
 import { FlexWrapper } from 'components/Container';
 import isElectron from 'is-electron';
+import ReplayIcon from '@mui/icons-material/Replay';
 
 interface PhotoswipeFullscreenAPI {
     enter: () => void;
@@ -635,15 +635,6 @@ function PhotoViewer(props: Iprops) {
                         }
                         onClick={() => downloadFileHelper(photoSwipe.currItem)}
                     />
-                    {showConvertBtn && (
-                        <ConvertBtnContainer>
-                            <Button
-                                color="secondary"
-                                onClick={triggerManualConvert}>
-                                {t('CONVERT')}
-                            </Button>
-                        </ConvertBtnContainer>
-                    )}
 
                     <Box
                         sx={{
@@ -750,6 +741,14 @@ function PhotoViewer(props: Iprops) {
                                         )}
                                     </button>
                                 )}
+                            {showConvertBtn && (
+                                <button
+                                    title={t('CONVERT')}
+                                    className="pswp__button pswp__button--custom"
+                                    onClick={triggerManualConvert}>
+                                    <ReplayIcon fontSize="small" />
+                                </button>
+                            )}
 
                             <div className="pswp__preloader">
                                 <div className="pswp__preloader__icn">

--- a/apps/photos/src/components/PhotoViewer/styledComponents/ConvertBtn.tsx
+++ b/apps/photos/src/components/PhotoViewer/styledComponents/ConvertBtn.tsx
@@ -1,9 +1,0 @@
-import { Paper, styled } from '@mui/material';
-
-export const ConvertBtnContainer = styled(Paper)`
-    border-radius: 4px;
-    position: absolute;
-    bottom: 10vh;
-    left: 2vh;
-    z-index: 10;
-`;


### PR DESCRIPTION
## Description

Moved the convert button to the top action bar

<img width="317" alt="image" src="https://github.com/ente-io/photos-web/assets/46242073/d15d8da6-61e4-4eb7-a66c-7829d2636076">

## Test Plan

tested locally 
