### PR TITLE
reorder preference options

### DIFF
--- a/apps/photos/src/components/Sidebar/Preferences/index.tsx
+++ b/apps/photos/src/components/Sidebar/Preferences/index.tsx
@@ -77,6 +77,17 @@ export default function Preferences({ open, onClose, onRootClose }) {
                 <Box px={'8px'}>
                     <Stack py="20px" spacing="24px">
                         <LanguageSelector />
+                        <EnteMenuItem
+                            variant="toggle"
+                            checked={!optOutOfCrashReports}
+                            onClick={toggleOptOutOfCrashReports}
+                            label={t('CRASH_REPORTING')}
+                        />{' '}
+                        <EnteMenuItem
+                            onClick={openMapSettings}
+                            endIcon={<ChevronRight />}
+                            label={t('MAP')}
+                        />
                         {isElectron() && (
                             <EnteMenuItem
                                 onClick={openAdvancedSettings}
@@ -84,17 +95,6 @@ export default function Preferences({ open, onClose, onRootClose }) {
                                 label={t('ADVANCED')}
                             />
                         )}
-                        <EnteMenuItem
-                            onClick={openMapSettings}
-                            endIcon={<ChevronRight />}
-                            label={t('MAP')}
-                        />
-                        <EnteMenuItem
-                            variant="toggle"
-                            checked={!optOutOfCrashReports}
-                            onClick={toggleOptOutOfCrashReports}
-                            label={t('CRASH_REPORTING')}
-                        />
                     </Stack>
                 </Box>
             </Stack>


### PR DESCRIPTION
## Description
- made `advanced` section the last item , seems like a better place 
- Having expandable items at the end seems more visually stable

### before 
<img width="382" alt="image" src="https://github.com/ente-io/photos-web/assets/46242073/33f271f9-280d-4acc-bae0-28b63414a78c">

### after 
<img width="419" alt="image" src="https://github.com/ente-io/photos-web/assets/46242073/aa9c57ac-c32f-4114-9f4f-f536797a446c">

## Test Plan
