### PR TITLE
Improve is-playback-possible logic

### DIFF
--- a/apps/photos/src/utils/photoFrame/index.ts
+++ b/apps/photos/src/utils/photoFrame/index.ts
@@ -10,11 +10,24 @@ export async function isPlaybackPossible(url: string): Promise<boolean> {
         const t = setTimeout(() => {
             resolve(false);
         }, WAIT_FOR_VIDEO_PLAYBACK);
+
         const video = document.createElement('video');
         video.addEventListener('canplay', function () {
             clearTimeout(t);
-            resolve(true);
+            video.remove(); // Clean up the video element
+            // also check for duration > 0 to make sure it is not a broken video
+            if (video.duration > 0) {
+                resolve(true);
+            } else {
+                resolve(false);
+            }
         });
+        video.addEventListener('error', function () {
+            clearTimeout(t);
+            video.remove();
+            resolve(false);
+        });
+
         video.src = url;
     });
 }


### PR DESCRIPTION
## Description

1. cleared video after use to prevent memory issues

2. improve handling by attaching an event listener to "error" too

3. consider video with length zero as unable playable

## Test Plan

tested locally 
