### PR TITLE
Upgrade heic-convert to ^2.0.0

### DIFF
--- a/apps/photos/package.json
+++ b/apps/photos/package.json
@@ -37,7 +37,7 @@
         "formik": "^2.1.5",
         "get-user-locale": "^2.1.3",
         "hdbscan": "0.0.1-alpha.5",
-        "heic-convert": "^1.2.4",
+        "heic-convert": "^2.0.0",
         "i18next": "^23.4.1",
         "i18next-http-backend": "^2.1.1",
         "idb": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2523,21 +2523,21 @@ hdbscan@0.0.1-alpha.5:
   dependencies:
     kd-tree-javascript "^1.0.3"
 
-heic-convert@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/heic-convert/-/heic-convert-1.2.4.tgz"
-  integrity sha512-klJHyv+BqbgKiCQvCqI9IKIvweCcohDuDl0Jphearj8+16+v8eff2piVevHqq4dW9TK0r1onTR6PKHP1I4hdbA==
+heic-convert@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/heic-convert/-/heic-convert-2.0.0.tgz#8250d56247310eb1121ef791a4b9ecf2cc0cc2a0"
+  integrity sha512-Kk2Ue5D7sAhyCmnHPLXQ4tzYH1qINmgppgqFn66x+DmClyL6sdmqGbHJ9cETy0Pxz5Ixz5w5JWJuIv9QqC1oKg==
   dependencies:
-    heic-decode "^1.1.2"
-    jpeg-js "^0.4.1"
-    pngjs "^3.4.0"
+    heic-decode "^2.0.0"
+    jpeg-js "^0.4.4"
+    pngjs "^6.0.0"
 
-heic-decode@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/heic-decode/-/heic-decode-1.1.2.tgz"
-  integrity sha512-UF8teegxvzQPdSTcx5frIUhitNDliz/9Pui0JFdIqVRE00spVE33DcCYtZqaLNyd4y5RP/QQWZFIc1YWVKKm2A==
+heic-decode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/heic-decode/-/heic-decode-2.0.0.tgz#77ab96ee1a255f0a9952d0e88d584bca30577114"
+  integrity sha512-NU+zsiDvdL+EebyTjrEqjkO2XYI7FgLhQzsbmO8dnnYce3S0PBSDm/ZyI4KpcGPXYEdb5W72vp/AQFuc4F8ASg==
   dependencies:
-    libheif-js "^1.10.0"
+    libheif-js "^1.17.1"
 
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -2904,9 +2904,9 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-jpeg-js@^0.4.1:
+jpeg-js@^0.4.4:
   version "0.4.4"
-  resolved "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
   integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
 
 js-sdsl@^4.1.4:
@@ -3006,10 +3006,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libheif-js@^1.10.0:
-  version "1.12.0"
-  resolved "https://registry.npmjs.org/libheif-js/-/libheif-js-1.12.0.tgz"
-  integrity sha512-hDs6xQ7028VOwAFwEtM0Q+B2x2NW69Jb2MhQFUbk3rUrHzz4qo5mqS8VrqNgYnSc8TiUGnR691LnO4uIfEE23w==
+libheif-js@^1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/libheif-js/-/libheif-js-1.17.1.tgz#7772cc5a31098df0354f0fadb49a939030765acd"
+  integrity sha512-g9wBm/CasGZMjmH3B2sD9+AO7Y5+79F0oPS+sdAulSxQeYeCeiTIP+lDqvlPofD+y76wvfVtotKZ8AuvZQnWgg==
 
 libsodium-wrappers@^0.7.8:
   version "0.7.9"
@@ -3609,10 +3609,10 @@ piexifjs@^1.0.6:
   resolved "https://registry.npmjs.org/piexifjs/-/piexifjs-1.0.6.tgz"
   integrity sha512-0wVyH0cKohzBQ5Gi2V1BuxYpxWfxF3cSqfFXfPIpl5tl9XLS5z4ogqhUCD20AbHi0h9aJkqXNJnkVev6gwh2ag==
 
-pngjs@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz"
-  integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
+pngjs@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-6.0.0.tgz#ca9e5d2aa48db0228a52c419c3308e87720da821"
+  integrity sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==
 
 postcss@8.4.14:
   version "8.4.14"


### PR DESCRIPTION
## Description
Fixes #1190

## Test Plan
 - Tested locally and verified that we can view existing heic files.
 - Verified that thumbnail generation and viewing the original file worked as expected for the file attached in the linked ticket.
