### PR TITLE
Show manage family portal option if add-on is active

### DIFF
--- a/apps/photos/src/components/pages/gallery/PlanSelector/card/free.tsx
+++ b/apps/photos/src/components/pages/gallery/PlanSelector/card/free.tsx
@@ -7,12 +7,14 @@ import { PeriodToggler } from '../periodToggler';
 import Plans from '../plans';
 import { hasAddOnBonus } from 'utils/billing';
 import { BFAddOnRow } from '../plans/BfAddOnRow';
+import { ManageSubscription } from '../manageSubscription';
 
 export default function FreeSubscriptionPlanSelectorCard({
     plans,
     subscription,
     bonusData,
     closeModal,
+    setLoading,
     planPeriod,
     togglePeriod,
     onPlanSelect,
@@ -46,6 +48,14 @@ export default function FreeSubscriptionPlanSelectorCard({
                         <BFAddOnRow
                             bonusData={bonusData}
                             closeModal={closeModal}
+                        />
+                    )}
+                    {hasAddOnBonus(bonusData) && (
+                        <ManageSubscription
+                            subscription={subscription}
+                            bonusData={bonusData}
+                            closeModal={closeModal}
+                            setLoading={setLoading}
                         />
                     )}
                 </Stack>

--- a/apps/photos/src/components/pages/gallery/PlanSelector/card/index.tsx
+++ b/apps/photos/src/components/pages/gallery/PlanSelector/card/index.tsx
@@ -191,6 +191,7 @@ function PlanSelectorCard(props: Props) {
                         subscription={subscription}
                         bonusData={bonusData}
                         closeModal={props.closeModal}
+                        setLoading={props.setLoading}
                         planPeriod={planPeriod}
                         togglePeriod={togglePeriod}
                         onPlanSelect={onPlanSelect}


### PR DESCRIPTION
## Description

## Test Plan
Tested locally
<img width="888" alt="image" src="https://github.com/ente-io/photos-web/assets/254676/f05147d0-c7c2-494f-a286-c2a5a219f237">
<img width="901" alt="image" src="https://github.com/ente-io/photos-web/assets/254676/eb6bc98e-d988-4a56-b789-bd434fdf606f">

