### PR TITLE
Freehand photo editor cropping mode

### DIFF
--- a/apps/photos/public/locales/en/translation.json
+++ b/apps/photos/public/locales/en/translation.json
@@ -626,6 +626,6 @@
     "INDEXED_ITEMS": "Indexed items",
     "CACHE_DIRECTORY": "Cache folder",
     "FREEHAND": "Freehand",
-    "APPLY": "Apply",
+    "APPLY_CROP": "Apply Crop",
     "PHOTO_EDIT_REQUIRED_TO_SAVE": "At least one transformation or color adjustment must be performed before saving."
 }

--- a/apps/photos/public/locales/en/translation.json
+++ b/apps/photos/public/locales/en/translation.json
@@ -626,5 +626,6 @@
     "INDEXED_ITEMS": "Indexed items",
     "CACHE_DIRECTORY": "Cache folder",
     "FREEHAND": "Freehand",
-    "APPLY": "Apply"
+    "APPLY": "Apply",
+    "PHOTO_EDIT_REQUIRED_TO_SAVE": "At least one transformation or color adjustment must be performed before saving."
 }

--- a/apps/photos/public/locales/en/translation.json
+++ b/apps/photos/public/locales/en/translation.json
@@ -624,5 +624,7 @@
     "FASTER_UPLOAD_DESCRIPTION": "Route uploads through nearby servers",
     "STATUS": "Status",
     "INDEXED_ITEMS": "Indexed items",
-    "CACHE_DIRECTORY": "Cache folder"
+    "CACHE_DIRECTORY": "Cache folder",
+    "FREEHAND": "Freehand",
+    "APPLY": "Apply"
 }

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/CropMenu.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/CropMenu.tsx
@@ -12,6 +12,7 @@ interface IProps {
     previewScale: number;
     cropBoxProps: CropBoxProps;
     cropBoxRef: MutableRefObject<HTMLDivElement>;
+    resetCropBox: () => void;
 }
 
 const CropMenu = (props: IProps) => {
@@ -59,6 +60,8 @@ const CropMenu = (props: IProps) => {
                 width,
                 height
             );
+
+            props.resetCropBox();
         };
     };
 

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/CropMenu.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/CropMenu.tsx
@@ -20,6 +20,7 @@ const CropMenu = (props: IProps) => {
         canvasLoading,
         setCanvasLoading,
         setTransformationPerformed,
+        setCurrentTab,
     } = useContext(ImageEditorOverlayContext);
 
     const [selectedRegionOfPreviewCanvas, setSelectedRegionOfPreviewCanvas] =
@@ -95,6 +96,8 @@ const CropMenu = (props: IProps) => {
                         const y2 = y1 + cropBoxRect.height;
 
                         cropRegionOfCanvas(canvasRef.current, x1, y1, x2, y2);
+
+                        setCurrentTab('transform');
                     }}
                     label="Apply"
                 />

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/CropMenu.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/CropMenu.tsx
@@ -3,9 +3,10 @@ import { MenuItemGroup } from 'components/Menu/MenuItemGroup';
 import MenuSectionTitle from 'components/Menu/MenuSectionTitle';
 import { useContext } from 'react';
 import { ImageEditorOverlayContext } from './';
-import CropSquareIcon from '@mui/icons-material/CropSquare';
 import { CropBoxProps } from './';
 import type { MutableRefObject } from 'react';
+import { t } from 'i18next';
+import CropIcon from '@mui/icons-material/Crop';
 
 interface IProps {
     previewScale: number;
@@ -63,14 +64,14 @@ const CropMenu = (props: IProps) => {
 
     return (
         <>
-            <MenuSectionTitle title={'freehand'} />
+            <MenuSectionTitle title={t('FREEHAND')} />
             <MenuItemGroup
                 style={{
                     marginBottom: '0.5rem',
                 }}>
                 <EnteMenuItem
                     disabled={canvasLoading}
-                    startIcon={<CropSquareIcon />}
+                    startIcon={<CropIcon />}
                     onClick={() => {
                         if (!props.cropBoxRef.current || !canvasRef.current)
                             return;
@@ -113,7 +114,7 @@ const CropMenu = (props: IProps) => {
 
                         setCurrentTab('transform');
                     }}
-                    label="Apply"
+                    label={t('APPLY')}
                 />
             </MenuItemGroup>
         </>

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/CropMenu.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/CropMenu.tsx
@@ -1,0 +1,80 @@
+import { EnteMenuItem } from 'components/Menu/EnteMenuItem';
+import { MenuItemGroup } from 'components/Menu/MenuItemGroup';
+import MenuSectionTitle from 'components/Menu/MenuSectionTitle';
+import { useContext } from 'react';
+import { ImageEditorOverlayContext } from './';
+import CropSquareIcon from '@mui/icons-material/CropSquare';
+import { CropBoxProps } from './';
+import type { MutableRefObject } from 'react';
+
+interface IProps {
+    previewScale: number;
+    cropBoxProps: CropBoxProps;
+    cropBoxRef: MutableRefObject<HTMLDivElement>;
+}
+
+const CropMenu = (props: IProps) => {
+    const {
+        canvasRef,
+        originalSizeCanvasRef,
+        canvasLoading,
+        setCanvasLoading,
+        setTransformationPerformed,
+    } = useContext(ImageEditorOverlayContext);
+
+    const cropRegionOfCanvas = (
+        canvas: HTMLCanvasElement,
+        topLeftX: number,
+        topLeftY: number,
+        bottomRightX: number,
+        bottomRightY: number
+    ) => {
+        const context = canvas.getContext('2d');
+        if (!context || !canvas) return;
+
+        const width = bottomRightX - topLeftX;
+        const height = bottomRightY - topLeftY;
+
+        const img = new Image();
+        img.src = canvas.toDataURL();
+        img.onload = () => {
+            context.clearRect(0, 0, canvas.width, canvas.height);
+
+            canvas.width = width;
+            canvas.height = height;
+
+            context.drawImage(
+                img,
+                topLeftX,
+                topLeftY,
+                width,
+                height,
+                0,
+                0,
+                width,
+                height
+            );
+        };
+    };
+
+    return (
+        <>
+            <MenuSectionTitle title={'freehand'} />
+            <MenuItemGroup
+                style={{
+                    marginBottom: '0.5rem',
+                }}>
+                <EnteMenuItem
+                    disabled={canvasLoading}
+                    startIcon={<CropSquareIcon />}
+                    onClick={() => {
+                        cropRegionOfCanvas();
+                    }}
+                    label="Apply"
+                />
+            </MenuItemGroup>
+        </>
+    );
+};
+
+export default CropMenu;

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/FreehandCropRegion.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/FreehandCropRegion.tsx
@@ -1,0 +1,118 @@
+import { CropBoxProps } from './';
+import type { Ref, Dispatch, SetStateAction, CSSProperties } from 'react';
+import { forwardRef } from 'react';
+
+const handleStyle: CSSProperties = {
+    position: 'absolute',
+    height: '10px',
+    width: '10px',
+    backgroundColor: 'white',
+    border: '1px solid black',
+};
+
+const seHandleStyle: CSSProperties = {
+    ...handleStyle,
+    right: '-5px',
+    bottom: '-5px',
+    cursor: 'se-resize',
+};
+
+interface IProps {
+    cropBox: CropBoxProps;
+    setIsDragging: Dispatch<SetStateAction<boolean>>;
+}
+
+const FreehandCropRegion = forwardRef(
+    (props: IProps, ref: Ref<HTMLDivElement>) => {
+        return (
+            <>
+                {/* Top overlay */}
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        height: props.cropBox.y + 'px', // height up to the top of the crop box
+                        backgroundColor: 'rgba(0,0,0,0.5)',
+                        pointerEvents: 'none',
+                    }}></div>
+
+                {/* Bottom overlay */}
+                <div
+                    style={{
+                        position: 'absolute',
+                        bottom: 0,
+                        left: 0,
+                        right: 0,
+                        height: `calc(100% - ${
+                            props.cropBox.y + props.cropBox.height
+                        }px)`, // height from the bottom of the crop box to the bottom of the canvas
+                        backgroundColor: 'rgba(0,0,0,0.5)',
+                        pointerEvents: 'none',
+                    }}></div>
+
+                {/* Left overlay */}
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: props.cropBox.y + 'px',
+                        left: 0,
+                        width: props.cropBox.x + 'px', // width up to the left side of the crop box
+                        height: props.cropBox.height + 'px', // same height as the crop box
+                        backgroundColor: 'rgba(0,0,0,0.5)',
+                        pointerEvents: 'none',
+                    }}></div>
+
+                {/* Right overlay */}
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: props.cropBox.y + 'px',
+                        right: 0,
+                        width: `calc(100% - ${
+                            props.cropBox.x + props.cropBox.width
+                        }px)`, // width from the right side of the crop box to the right side of the canvas
+                        height: props.cropBox.height + 'px', // same height as the crop box
+                        backgroundColor: 'rgba(0,0,0,0.5)',
+                        pointerEvents: 'none',
+                    }}></div>
+
+                <div
+                    style={{
+                        display: 'grid',
+                        position: 'absolute',
+                        left: props.cropBox.x + 'px',
+                        top: props.cropBox.y + 'px',
+                        width: props.cropBox.width + 'px',
+                        height: props.cropBox.height + 'px',
+                        border: '1px solid white',
+                        gridTemplateColumns: '1fr 1fr 1fr',
+                        gridTemplateRows: '1fr 1fr 1fr',
+                        gap: '0px',
+                        zIndex: 30, // make sure the crop box is above the overlays
+                    }}
+                    ref={ref}>
+                    {Array.from({ length: 9 }).map((_, index) => (
+                        <div
+                            key={index}
+                            style={{
+                                border: '1px solid white',
+                                boxSizing: 'border-box',
+                                pointerEvents: 'none',
+                            }}></div>
+                    ))}
+
+                    <div
+                        style={seHandleStyle}
+                        onMouseDown={(e) => {
+                            e.preventDefault();
+                            props.setIsDragging(true);
+                        }}></div>
+                </div>
+            </>
+        );
+    }
+);
+
+export default FreehandCropRegion;

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/TransformMenu.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/TransformMenu.tsx
@@ -89,6 +89,7 @@ const TransformMenu = () => {
             );
         };
     };
+
     const flipCanvas = (
         canvas: HTMLCanvasElement,
         direction: 'vertical' | 'horizontal'

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -46,7 +46,7 @@ import { logError } from '@ente/shared/sentry';
 import { getFileType } from 'services/typeDetectionService';
 import { downloadUsingAnchor } from '@ente/shared/utils';
 import { CORNER_THRESHOLD, FILTER_DEFAULT_VALUES } from 'constants/photoEditor';
-import type { CSSProperties } from 'react';
+import FreehandCropRegion from './FreehandCropRegion';
 
 interface IProps {
     file: EnteFile;
@@ -73,21 +73,6 @@ const getEditedFileName = (fileName: string) => {
     const extension = fileNameParts.pop();
     const editedFileName = `${fileNameParts.join('.')}-edited.${extension}`;
     return editedFileName;
-};
-
-const handleStyle: CSSProperties = {
-    position: 'absolute',
-    height: '10px',
-    width: '10px',
-    backgroundColor: 'white',
-    border: '1px solid black',
-};
-
-const seHandleStyle: CSSProperties = {
-    ...handleStyle,
-    right: '-5px',
-    bottom: '-5px',
-    cursor: 'se-resize',
 };
 
 export interface CropBoxProps {
@@ -599,101 +584,11 @@ const ImageEditorOverlay = (props: IProps) => {
                                 />
 
                                 {currentTab === 'crop' && (
-                                    <>
-                                        {/* Top overlay */}
-                                        <div
-                                            style={{
-                                                position: 'absolute',
-                                                top: 0,
-                                                left: 0,
-                                                right: 0,
-                                                height: cropBox.y + 'px', // height up to the top of the crop box
-                                                backgroundColor:
-                                                    'rgba(0,0,0,0.5)',
-                                                pointerEvents: 'none',
-                                            }}></div>
-
-                                        {/* Bottom overlay */}
-                                        <div
-                                            style={{
-                                                position: 'absolute',
-                                                bottom: 0,
-                                                left: 0,
-                                                right: 0,
-                                                height: `calc(100% - ${
-                                                    cropBox.y + cropBox.height
-                                                }px)`, // height from the bottom of the crop box to the bottom of the canvas
-                                                backgroundColor:
-                                                    'rgba(0,0,0,0.5)',
-                                                pointerEvents: 'none',
-                                            }}></div>
-
-                                        {/* Left overlay */}
-                                        <div
-                                            style={{
-                                                position: 'absolute',
-                                                top: cropBox.y + 'px',
-                                                left: 0,
-                                                width: cropBox.x + 'px', // width up to the left side of the crop box
-                                                height: cropBox.height + 'px', // same height as the crop box
-                                                backgroundColor:
-                                                    'rgba(0,0,0,0.5)',
-                                                pointerEvents: 'none',
-                                            }}></div>
-
-                                        {/* Right overlay */}
-                                        <div
-                                            style={{
-                                                position: 'absolute',
-                                                top: cropBox.y + 'px',
-                                                right: 0,
-                                                width: `calc(100% - ${
-                                                    cropBox.x + cropBox.width
-                                                }px)`, // width from the right side of the crop box to the right side of the canvas
-                                                height: cropBox.height + 'px', // same height as the crop box
-                                                backgroundColor:
-                                                    'rgba(0,0,0,0.5)',
-                                                pointerEvents: 'none',
-                                            }}></div>
-
-                                        <div
-                                            style={{
-                                                display: 'grid',
-                                                position: 'absolute',
-                                                left: cropBox.x + 'px',
-                                                top: cropBox.y + 'px',
-                                                width: cropBox.width + 'px',
-                                                height: cropBox.height + 'px',
-                                                border: '1px solid white',
-                                                gridTemplateColumns:
-                                                    '1fr 1fr 1fr',
-                                                gridTemplateRows: '1fr 1fr 1fr',
-                                                gap: '0px',
-                                                zIndex: 30, // make sure the crop box is above the overlays
-                                            }}
-                                            ref={cropBoxRef}>
-                                            {Array.from({ length: 9 }).map(
-                                                (_, index) => (
-                                                    <div
-                                                        key={index}
-                                                        style={{
-                                                            border: '1px solid white',
-                                                            boxSizing:
-                                                                'border-box',
-                                                            pointerEvents:
-                                                                'none',
-                                                        }}></div>
-                                                )
-                                            )}
-
-                                            <div
-                                                style={seHandleStyle}
-                                                onMouseDown={(e) => {
-                                                    e.preventDefault();
-                                                    setIsDragging(true);
-                                                }}></div>
-                                        </div>
-                                    </>
+                                    <FreehandCropRegion
+                                        cropBox={cropBox}
+                                        ref={cropBoxRef}
+                                        setIsDragging={setIsDragging}
+                                    />
                                 )}
                             </Box>
                         </Box>

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -592,67 +592,139 @@ const ImageEditorOverlay = (props: IProps) => {
                         onMouseMove={isDragging ? handleDrag : null}
                         onMouseDown={handleDragStart}>
                         <Box
-                            height="90%"
-                            width="100%"
-                            ref={parentRef}
-                            display="flex"
-                            alignItems="center"
-                            justifyContent="center"
-                            position="relative">
-                            {(fileURL === null || canvasLoading) && (
-                                <CircularProgress />
-                            )}
+                            style={{
+                                position: 'relative',
+                                width: '100%',
+                                height: '100%',
+                            }}>
+                            <Box
+                                height="90%"
+                                width="100%"
+                                ref={parentRef}
+                                display="flex"
+                                alignItems="center"
+                                justifyContent="center"
+                                position="relative">
+                                {(fileURL === null || canvasLoading) && (
+                                    <CircularProgress />
+                                )}
 
-                            <canvas
-                                ref={canvasRef}
-                                style={{
-                                    objectFit: 'contain',
-                                    display:
-                                        fileURL === null || canvasLoading
-                                            ? 'none'
-                                            : 'block',
-                                    position: 'absolute',
-                                }}
-                            />
-                            <canvas
-                                ref={originalSizeCanvasRef}
-                                style={{
-                                    display: 'none',
-                                }}
-                            />
-                            <div
-                                style={{
-                                    display:
-                                        currentTab === 'crop' ? 'grid' : 'none',
-                                    position: 'absolute',
-                                    left: cropBox.x + 'px',
-                                    top: cropBox.y + 'px',
-                                    width: cropBox.width + 'px',
-                                    height: cropBox.height + 'px',
-                                    backgroundColor: 'rgba(0,0,0,0.5)',
-                                    border: '1px solid white',
-                                    gridTemplateColumns: '1fr 1fr 1fr',
-                                    gridTemplateRows: '1fr 1fr 1fr',
-                                    gap: '0px',
-                                }}
-                                ref={cropBoxRef}>
-                                {Array.from({ length: 9 }).map((_, index) => (
-                                    <div
-                                        key={index}
-                                        style={{
-                                            border: '1px solid white',
-                                            boxSizing: 'border-box',
-                                            pointerEvents: 'none',
-                                        }}></div>
-                                ))}
+                                <canvas
+                                    ref={canvasRef}
+                                    style={{
+                                        objectFit: 'contain',
+                                        display:
+                                            fileURL === null || canvasLoading
+                                                ? 'none'
+                                                : 'block',
+                                        position: 'absolute',
+                                    }}
+                                />
+                                <canvas
+                                    ref={originalSizeCanvasRef}
+                                    style={{
+                                        display: 'none',
+                                    }}
+                                />
 
-                                <div
-                                    style={seHandleStyle}
-                                    onMouseDown={(e) => {
-                                        e.preventDefault();
-                                        setIsDragging(true);
-                                    }}></div>
-                            </div>
+                                {currentTab === 'crop' && (
+                                    <>
+                                        {/* Top overlay */}
+                                        <div
+                                            style={{
+                                                position: 'absolute',
+                                                top: 0,
+                                                left: 0,
+                                                right: 0,
+                                                height: cropBox.y + 'px', // height up to the top of the crop box
+                                                backgroundColor:
+                                                    'rgba(0,0,0,0.5)',
+                                                pointerEvents: 'none',
+                                            }}></div>
+
+                                        {/* Bottom overlay */}
+                                        <div
+                                            style={{
+                                                position: 'absolute',
+                                                bottom: 0,
+                                                left: 0,
+                                                right: 0,
+                                                height: `calc(100% - ${
+                                                    cropBox.y + cropBox.height
+                                                }px)`, // height from the bottom of the crop box to the bottom of the canvas
+                                                backgroundColor:
+                                                    'rgba(0,0,0,0.5)',
+                                                pointerEvents: 'none',
+                                            }}></div>
+
+                                        {/* Left overlay */}
+                                        <div
+                                            style={{
+                                                position: 'absolute',
+                                                top: cropBox.y + 'px',
+                                                left: 0,
+                                                width: cropBox.x + 'px', // width up to the left side of the crop box
+                                                height: cropBox.height + 'px', // same height as the crop box
+                                                backgroundColor:
+                                                    'rgba(0,0,0,0.5)',
+                                                pointerEvents: 'none',
+                                            }}></div>
+
+                                        {/* Right overlay */}
+                                        <div
+                                            style={{
+                                                position: 'absolute',
+                                                top: cropBox.y + 'px',
+                                                right: 0,
+                                                width: `calc(100% - ${
+                                                    cropBox.x + cropBox.width
+                                                }px)`, // width from the right side of the crop box to the right side of the canvas
+                                                height: cropBox.height + 'px', // same height as the crop box
+                                                backgroundColor:
+                                                    'rgba(0,0,0,0.5)',
+                                                pointerEvents: 'none',
+                                            }}></div>
+
+                                        <div
+                                            style={{
+                                                display: 'grid',
+                                                position: 'absolute',
+                                                left: cropBox.x + 'px',
+                                                top: cropBox.y + 'px',
+                                                width: cropBox.width + 'px',
+                                                height: cropBox.height + 'px',
+                                                border: '1px solid white',
+                                                gridTemplateColumns:
+                                                    '1fr 1fr 1fr',
+                                                gridTemplateRows: '1fr 1fr 1fr',
+                                                gap: '0px',
+                                                zIndex: 30, // make sure the crop box is above the overlays
+                                            }}
+                                            ref={cropBoxRef}>
+                                            {Array.from({ length: 9 }).map(
+                                                (_, index) => (
+                                                    <div
+                                                        key={index}
+                                                        style={{
+                                                            border: '1px solid white',
+                                                            boxSizing:
+                                                                'border-box',
+                                                            pointerEvents:
+                                                                'none',
+                                                        }}></div>
+                                                )
+                                            )}
+
+                                            <div
+                                                style={seHandleStyle}
+                                                onMouseDown={(e) => {
+                                                    e.preventDefault();
+                                                    setIsDragging(true);
+                                                }}></div>
+                                        </div>
+                                    </>
+                                )}
+                            </Box>
                         </Box>
                     </Box>
                 </Box>

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -45,11 +45,7 @@ import { getEditorCloseConfirmationMessage } from 'utils/ui';
 import { logError } from '@ente/shared/sentry';
 import { getFileType } from 'services/typeDetectionService';
 import { downloadUsingAnchor } from '@ente/shared/utils';
-import {
-    CORNER_THRESHOLD,
-    DEFAULT_CROPBOX_DIMENSIONS,
-    FILTER_DEFAULT_VALUES,
-} from 'constants/photoEditor';
+import { CORNER_THRESHOLD, FILTER_DEFAULT_VALUES } from 'constants/photoEditor';
 import type { CSSProperties } from 'react';
 
 interface IProps {
@@ -153,7 +149,10 @@ const ImageEditorOverlay = (props: IProps) => {
     const cropBoxRef = useRef<HTMLDivElement>(null);
 
     const getCanvasBoundsOffsets = () => {
-        const canvasBounds = canvasRef.current.getBoundingClientRect();
+        const canvasBounds = {
+            height: canvasRef.current.height,
+            width: canvasRef.current.width,
+        };
         const parentBounds = parentRef.current.getBoundingClientRect();
 
         // calculate the offset created by centering the canvas in its parent
@@ -260,14 +259,14 @@ const ImageEditorOverlay = (props: IProps) => {
 
     const resetCropBox = () => {
         setCropBox((prev) => {
-            const { offsetX, offsetY } = getCanvasBoundsOffsets();
+            const { offsetX, offsetY, canvasBounds } = getCanvasBoundsOffsets();
 
             return {
                 ...prev,
                 x: offsetX,
                 y: offsetY,
-                height: DEFAULT_CROPBOX_DIMENSIONS.height,
-                width: DEFAULT_CROPBOX_DIMENSIONS.width,
+                height: canvasBounds.height,
+                width: canvasBounds.width,
             };
         });
     };
@@ -364,13 +363,8 @@ const ImageEditorOverlay = (props: IProps) => {
                 return;
             }
 
-            resetCropBox();
-            setStartX(0);
-            setStartY(0);
-            setIsDragging(false);
-            setIsGrowing(false);
-
             setCanvasLoading(true);
+
             resetFilters();
             setCurrentRotationAngle(0);
 
@@ -415,6 +409,13 @@ const ImageEditorOverlay = (props: IProps) => {
                         setColoursAdjusted(false);
 
                         setCanvasLoading(false);
+
+                        resetCropBox();
+                        setStartX(0);
+                        setStartY(0);
+                        setIsDragging(false);
+                        setIsGrowing(false);
+
                         resolve(true);
                     } catch (e) {
                         reject(e);

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -783,14 +783,25 @@ const ImageEditorOverlay = (props: IProps) => {
                             startIcon={<DownloadIcon />}
                             onClick={downloadEditedPhoto}
                             label={t('DOWNLOAD_EDITED')}
+                            disabled={
+                                !transformationPerformed && !coloursAdjusted
+                            }
                         />
                         <MenuItemDivider />
                         <EnteMenuItem
                             startIcon={<CloudUploadIcon />}
                             onClick={saveCopyToEnte}
                             label={t('SAVE_A_COPY_TO_ENTE')}
+                            disabled={
+                                !transformationPerformed && !coloursAdjusted
+                            }
                         />
                     </MenuItemGroup>
+                    {!transformationPerformed && !coloursAdjusted && (
+                        <MenuSectionTitle
+                            title={t('PHOTO_EDIT_REQUIRED_TO_SAVE')}
+                        />
+                    )}
                 </EnteDrawer>
             </Backdrop>
         </>

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -788,6 +788,7 @@ const ImageEditorOverlay = (props: IProps) => {
                                 previewScale={previewCanvasScale}
                                 cropBoxProps={cropBox}
                                 cropBoxRef={cropBoxRef}
+                                resetCropBox={resetCropBox}
                             />
                         )}
                         {currentTab === 'transform' && <TransformMenu />}

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -177,6 +177,22 @@ const ImageEditorOverlay = (props: IProps) => {
 
     const cropBoxRef = useRef<HTMLDivElement>(null);
 
+    const getCanvasBoundsOffsets = () => {
+        const canvasBounds = canvasRef.current.getBoundingClientRect();
+        const parentBounds = parentRef.current.getBoundingClientRect();
+
+        // calculate the offset created by centering the canvas in its parent
+        const offsetX = (parentBounds.width - canvasBounds.width) / 2;
+        const offsetY = (parentBounds.height - canvasBounds.height) / 2;
+
+        return {
+            offsetY,
+            offsetX,
+            canvasBounds,
+            parentBounds,
+        };
+    };
+
     const handleDragStart = (e) => {
         if (currentTab !== 'crop') return;
 
@@ -214,12 +230,8 @@ const ImageEditorOverlay = (props: IProps) => {
         const dx = e.pageX - startX;
         const dy = e.pageY - startY;
 
-        const canvasBounds = canvasRef.current.getBoundingClientRect();
-        const parentBounds = parentRef.current.getBoundingClientRect();
-
-        // calculate the offset created by centering the canvas in its parent
-        const offsetX = (parentBounds.width - canvasBounds.width) / 2;
-        const offsetY = (parentBounds.height - canvasBounds.height) / 2;
+        const { offsetX, offsetY, canvasBounds, parentBounds } =
+            getCanvasBoundsOffsets();
 
         if (isGrowing) {
             setCropBox((prev) => {
@@ -271,6 +283,24 @@ const ImageEditorOverlay = (props: IProps) => {
         setIsGrowing(false);
         setIsDragging(false);
     };
+
+    const moveCropBoxToTopLeft = () => {
+        const { offsetX, offsetY, canvasBounds, parentBounds } =
+            getCanvasBoundsOffsets();
+
+        // Set the crop box position to the top-left corner of the canvas, accounting for the offset
+        setCropBox((prev) => ({
+            ...prev,
+            x: offsetX,
+            y: offsetY,
+        }));
+    };
+
+    useEffect(() => {
+        if (!canvasRef.current || !parentRef.current || !cropBoxRef.current)
+            return;
+        moveCropBoxToTopLeft();
+    }, [canvasRef.current, parentRef.current, cropBoxRef.current]);
 
     useEffect(() => {
         if (!canvasRef.current) {

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -562,7 +562,10 @@ const ImageEditorOverlay = (props: IProps) => {
                         display="flex"
                         alignItems="center"
                         justifyContent="center"
-                        position="relative">
+                        position="relative"
+                        onMouseUp={handleDragEnd}
+                        onMouseMove={isDragging ? handleDrag : null}
+                        onMouseDown={handleDragStart}>
                         <Box
                             height="90%"
                             width="100%"
@@ -570,9 +573,6 @@ const ImageEditorOverlay = (props: IProps) => {
                             display="flex"
                             alignItems="center"
                             justifyContent="center"
-                            onMouseUp={handleDragEnd}
-                            onMouseMove={isDragging ? handleDrag : null}
-                            onMouseDown={handleDragStart}
                             position="relative">
                             {(fileURL === null || canvasLoading) && (
                                 <CircularProgress />

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -281,6 +281,7 @@ const ImageEditorOverlay = (props: IProps) => {
     useEffect(() => {
         if (currentTab !== 'crop') return;
         resetCropBox();
+        setShowControlsDrawer(false);
     }, [currentTab]);
 
     const applyFilters = async (canvases: HTMLCanvasElement[]) => {

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -50,6 +50,7 @@ import {
     DEFAULT_CROPBOX_DIMENSIONS,
     FILTER_DEFAULT_VALUES,
 } from 'constants/photoEditor';
+import type { CSSProperties } from 'react';
 
 interface IProps {
     file: EnteFile;
@@ -78,7 +79,7 @@ const getEditedFileName = (fileName: string) => {
     return editedFileName;
 };
 
-const handleStyle = {
+const handleStyle: CSSProperties = {
     position: 'absolute',
     height: '10px',
     width: '10px',
@@ -86,7 +87,7 @@ const handleStyle = {
     border: '1px solid black',
 };
 
-const seHandleStyle = {
+const seHandleStyle: CSSProperties = {
     ...handleStyle,
     right: '-5px',
     bottom: '-5px',

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -278,6 +278,11 @@ const ImageEditorOverlay = (props: IProps) => {
         }
     }, [brightness, contrast, blur, saturation, invert, canvasRef, fileURL]);
 
+    useEffect(() => {
+        if (currentTab !== 'crop') return;
+        resetCropBox();
+    }, [currentTab]);
+
     const applyFilters = async (canvases: HTMLCanvasElement[]) => {
         try {
             for (const canvas of canvases) {

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -394,12 +394,7 @@ const ImageEditorOverlay = (props: IProps) => {
                 return;
             }
 
-            setCropBox({
-                x: 0,
-                y: 0,
-                width: 100,
-                height: 100,
-            });
+            moveCropBoxToTopLeft();
             setStartX(0);
             setStartY(0);
             setIsDragging(false);

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -47,6 +47,10 @@ import { getFileType } from 'services/typeDetectionService';
 import { downloadUsingAnchor } from '@ente/shared/utils';
 import { CORNER_THRESHOLD, FILTER_DEFAULT_VALUES } from 'constants/photoEditor';
 import FreehandCropRegion from './FreehandCropRegion';
+import EnteButton from '@ente/shared/components/EnteButton';
+import { CenteredFlex } from '@ente/shared/components/Container';
+import CropIcon from '@mui/icons-material/Crop';
+import { cropRegionOfCanvas, getCropRegionArgs } from './CropMenu';
 
 interface IProps {
     file: EnteFile;
@@ -591,6 +595,48 @@ const ImageEditorOverlay = (props: IProps) => {
                                     />
                                 )}
                             </Box>
+                            {currentTab === 'crop' && (
+                                <CenteredFlex marginTop="1rem">
+                                    <EnteButton
+                                        color="accent"
+                                        startIcon={<CropIcon />}
+                                        onClick={() => {
+                                            if (
+                                                !cropBoxRef.current ||
+                                                !canvasRef.current
+                                            )
+                                                return;
+
+                                            const { x1, x2, y1, y2 } =
+                                                getCropRegionArgs(
+                                                    cropBoxRef.current,
+                                                    canvasRef.current
+                                                );
+                                            setCanvasLoading(true);
+                                            setTransformationPerformed(true);
+                                            cropRegionOfCanvas(
+                                                canvasRef.current,
+                                                x1,
+                                                y1,
+                                                x2,
+                                                y2
+                                            );
+                                            cropRegionOfCanvas(
+                                                originalSizeCanvasRef.current,
+                                                x1 / previewCanvasScale,
+                                                y1 / previewCanvasScale,
+                                                x2 / previewCanvasScale,
+                                                y2 / previewCanvasScale
+                                            );
+                                            resetCropBox();
+                                            setCanvasLoading(false);
+
+                                            setCurrentTab('transform');
+                                        }}>
+                                        {t('APPLY_CROP')}
+                                    </EnteButton>
+                                </CenteredFlex>
+                            )}
                         </Box>
                     </Box>
                 </Box>

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -623,9 +623,7 @@ const ImageEditorOverlay = (props: IProps) => {
                             <div
                                 style={{
                                     display:
-                                        currentTab === 'crop'
-                                            ? 'inline-block'
-                                            : 'none',
+                                        currentTab === 'crop' ? 'grid' : 'none',
                                     position: 'absolute',
                                     left: cropBox.x + 'px',
                                     top: cropBox.y + 'px',
@@ -633,8 +631,21 @@ const ImageEditorOverlay = (props: IProps) => {
                                     height: cropBox.height + 'px',
                                     backgroundColor: 'rgba(0,0,0,0.5)',
                                     border: '1px solid white',
+                                    gridTemplateColumns: '1fr 1fr 1fr',
+                                    gridTemplateRows: '1fr 1fr 1fr',
+                                    gap: '0px',
                                 }}
                                 ref={cropBoxRef}>
+                                {Array.from({ length: 9 }).map((_, index) => (
+                                    <div
+                                        key={index}
+                                        style={{
+                                            border: '1px solid white',
+                                            boxSizing: 'border-box',
+                                            pointerEvents: 'none',
+                                        }}></div>
+                                ))}
+
                                 <div
                                     style={seHandleStyle}
                                     onMouseDown={(e) => {

--- a/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
+++ b/apps/photos/src/components/PhotoViewer/ImageEditorOverlay/index.tsx
@@ -45,6 +45,11 @@ import { getEditorCloseConfirmationMessage } from 'utils/ui';
 import { logError } from '@ente/shared/sentry';
 import { getFileType } from 'services/typeDetectionService';
 import { downloadUsingAnchor } from '@ente/shared/utils';
+import {
+    CORNER_THRESHOLD,
+    DEFAULT_CROPBOX_DIMENSIONS,
+    FILTER_DEFAULT_VALUES,
+} from 'constants/photoEditor';
 
 interface IProps {
     file: EnteFile;
@@ -66,27 +71,11 @@ export const ImageEditorOverlayContext = createContext(
 
 type OperationTab = 'crop' | 'transform' | 'colours';
 
-const filterDefaultValues = {
-    brightness: 100,
-    contrast: 100,
-    blur: 0,
-    saturation: 100,
-    invert: false,
-};
-
 const getEditedFileName = (fileName: string) => {
     const fileNameParts = fileName.split('.');
     const extension = fileNameParts.pop();
     const editedFileName = `${fileNameParts.join('.')}-edited.${extension}`;
     return editedFileName;
-};
-
-// CORNER_THRESHOLD defines the threshold near the corners of the crop box in which dragging is assumed as not the intention
-const CORNER_THRESHOLD = 20;
-
-const DEFAULT_CROPBOX_DIMENSIONS = {
-    height: 100,
-    width: 100,
 };
 
 const handleStyle = {
@@ -97,32 +86,11 @@ const handleStyle = {
     border: '1px solid black',
 };
 
-const nwHandleStyle = {
-    ...handleStyle,
-    left: '-5px',
-    top: '-5px',
-    cursor: 'nw-resize',
-};
-
-const neHandleStyle = {
-    ...handleStyle,
-    right: '-5px',
-    top: '-5px',
-    cursor: 'ne-resize',
-};
-
 const seHandleStyle = {
     ...handleStyle,
     right: '-5px',
     bottom: '-5px',
     cursor: 'se-resize',
-};
-
-const swHandleStyle = {
-    ...handleStyle,
-    left: '-5px',
-    bottom: '-5px',
-    cursor: 'sw-resize',
 };
 
 export interface CropBoxProps {
@@ -146,14 +114,14 @@ const ImageEditorOverlay = (props: IProps) => {
     const [currentTab, setCurrentTab] = useState<OperationTab>('transform');
 
     const [brightness, setBrightness] = useState(
-        filterDefaultValues.brightness
+        FILTER_DEFAULT_VALUES.brightness
     );
-    const [contrast, setContrast] = useState(filterDefaultValues.contrast);
-    const [blur, setBlur] = useState(filterDefaultValues.blur);
+    const [contrast, setContrast] = useState(FILTER_DEFAULT_VALUES.contrast);
+    const [blur, setBlur] = useState(FILTER_DEFAULT_VALUES.blur);
     const [saturation, setSaturation] = useState(
-        filterDefaultValues.saturation
+        FILTER_DEFAULT_VALUES.saturation
     );
-    const [invert, setInvert] = useState(filterDefaultValues.invert);
+    const [invert, setInvert] = useState(FILTER_DEFAULT_VALUES.invert);
 
     const [transformationPerformed, setTransformationPerformed] =
         useState(false);
@@ -310,11 +278,11 @@ const ImageEditorOverlay = (props: IProps) => {
         try {
             applyFilters([canvasRef.current, originalSizeCanvasRef.current]);
             setColoursAdjusted(
-                brightness !== filterDefaultValues.brightness ||
-                    contrast !== filterDefaultValues.contrast ||
-                    blur !== filterDefaultValues.blur ||
-                    saturation !== filterDefaultValues.saturation ||
-                    invert !== filterDefaultValues.invert
+                brightness !== FILTER_DEFAULT_VALUES.brightness ||
+                    contrast !== FILTER_DEFAULT_VALUES.contrast ||
+                    blur !== FILTER_DEFAULT_VALUES.blur ||
+                    saturation !== FILTER_DEFAULT_VALUES.saturation ||
+                    invert !== FILTER_DEFAULT_VALUES.invert
             );
         } catch (e) {
             logError(e, 'Error applying filters');

--- a/apps/photos/src/constants/photoEditor.ts
+++ b/apps/photos/src/constants/photoEditor.ts
@@ -8,8 +8,3 @@ export const FILTER_DEFAULT_VALUES = {
 
 // CORNER_THRESHOLD defines the threshold near the corners of the crop box in which dragging is assumed as not the intention
 export const CORNER_THRESHOLD = 20;
-
-export const DEFAULT_CROPBOX_DIMENSIONS = {
-    height: 100,
-    width: 100,
-};

--- a/apps/photos/src/constants/photoEditor.ts
+++ b/apps/photos/src/constants/photoEditor.ts
@@ -1,0 +1,15 @@
+export const FILTER_DEFAULT_VALUES = {
+    brightness: 100,
+    contrast: 100,
+    blur: 0,
+    saturation: 100,
+    invert: false,
+};
+
+// CORNER_THRESHOLD defines the threshold near the corners of the crop box in which dragging is assumed as not the intention
+export const CORNER_THRESHOLD = 20;
+
+export const DEFAULT_CROPBOX_DIMENSIONS = {
+    height: 100,
+    width: 100,
+};


### PR DESCRIPTION
## Description

Addresses https://github.com/ente-io/photos-desktop/issues/300

* Adds a new "Crop" tab in the photo editor
* Allows users to drag and resize the cropping region
* Scales the crop region accordingly with the full-sized image

## Test Plan
