### PR TITLE
Remain in the same collection during move operation

### DIFF
--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -842,7 +842,6 @@ export default function Gallery() {
                 if (isInHiddenSection && ops === COLLECTION_OPS_TYPE.UNHIDE) {
                     exitHiddenSection();
                 }
-                setActiveCollectionID(collection.id);
             } catch (e) {
                 logError(e, 'collection ops failed', { ops });
                 setDialogMessage({

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -836,7 +836,17 @@ export default function Gallery() {
                         selected.collectionID
                     );
                 }
-
+                if (selected?.ownCount === filteredData?.length) {
+                    if (
+                        ops === COLLECTION_OPS_TYPE.REMOVE ||
+                        ops === COLLECTION_OPS_TYPE.RESTORE ||
+                        ops === COLLECTION_OPS_TYPE.MOVE
+                    ) {
+                        setActiveCollectionID(ALL_SECTION);
+                    } else if (ops === COLLECTION_OPS_TYPE.UNHIDE) {
+                        exitHiddenSection();
+                    }
+                }
                 clearSelection();
                 await syncWithRemote(false, true);
             } catch (e) {
@@ -872,6 +882,14 @@ export default function Gallery() {
                     setHiddenFileIds,
                     setFixCreationTimeAttributes
                 );
+            }
+            if (
+                selected?.ownCount === filteredData?.length &&
+                ops !== FILE_OPS_TYPE.ARCHIVE &&
+                ops !== FILE_OPS_TYPE.DOWNLOAD &&
+                ops !== FILE_OPS_TYPE.FIX_TIME
+            ) {
+                setActiveCollectionID(ALL_SECTION);
             }
             clearSelection();
             await syncWithRemote(false, true);

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -842,6 +842,7 @@ export default function Gallery() {
                         ops === COLLECTION_OPS_TYPE.RESTORE ||
                         ops === COLLECTION_OPS_TYPE.MOVE
                     ) {
+                        // redirect to all section when no items are left in the current collection.
                         setActiveCollectionID(ALL_SECTION);
                     } else if (ops === COLLECTION_OPS_TYPE.UNHIDE) {
                         exitHiddenSection();

--- a/apps/photos/src/pages/gallery/index.tsx
+++ b/apps/photos/src/pages/gallery/index.tsx
@@ -839,9 +839,6 @@ export default function Gallery() {
 
                 clearSelection();
                 await syncWithRemote(false, true);
-                if (isInHiddenSection && ops === COLLECTION_OPS_TYPE.UNHIDE) {
-                    exitHiddenSection();
-                }
             } catch (e) {
                 logError(e, 'collection ops failed', { ops });
                 setDialogMessage({


### PR DESCRIPTION
## Description

^ title 
- now user stays in the origin collection even after the collection operation is completed including unhide photos

fixes #1554 


## Test Plan

tested locally 
