### PR TITLE
Allow using uncategorized as replacement album

### DIFF
--- a/apps/photos/src/components/Upload/Uploader.tsx
+++ b/apps/photos/src/components/Upload/Uploader.tsx
@@ -391,7 +391,7 @@ export default function Uploader(props: Props) {
     ) => {
         try {
             addLogLine(
-                `upload file to an existing collection - "${collection.name}"`
+                `upload file to an existing collection name:${collection.name}, collectionID:${collection.id}`
             );
             await preCollectionCreationAction();
             const filesWithCollectionToUpload: FileWithCollection[] =

--- a/apps/photos/src/utils/collection/index.ts
+++ b/apps/photos/src/utils/collection/index.ts
@@ -521,7 +521,8 @@ export function isValidReplacementAlbum(
     return (
         collection.name === wantedCollectionName &&
         (collection.type === CollectionType.album ||
-            collection.type === CollectionType.folder) &&
+            collection.type === CollectionType.folder ||
+            collection.type === CollectionType.uncategorized) &&
         !isHiddenCollection(collection) &&
         !isQuickLinkCollection(collection) &&
         !isIncomingShare(collection, user)

--- a/apps/photos/src/utils/collection/index.ts
+++ b/apps/photos/src/utils/collection/index.ts
@@ -52,6 +52,7 @@ import {
 } from 'utils/export';
 import exportService from 'services/export';
 import { CollectionDownloadProgressAttributes } from 'components/Collections/CollectionDownloadProgress';
+import { addLogLine } from '@ente/shared/logging';
 
 export enum COLLECTION_OPS_TYPE {
     ADD,
@@ -611,8 +612,13 @@ export const getOrCreateAlbum = async (
     }
     for (const collection of existingCollections) {
         if (isValidReplacementAlbum(collection, user, albumName)) {
+            addLogLine(
+                `Found existing album ${albumName} with id ${collection.id}`
+            );
             return collection;
         }
     }
-    return createAlbum(albumName);
+    const album = await createAlbum(albumName);
+    addLogLine(`Created new album ${albumName} with id ${album.id}`);
+    return album;
 };


### PR DESCRIPTION
## Description

^ title

fixes the issue, of upload resuming when the user has selected uncategorized as the target collection, it creates a new album named "uncategorized"

## Test Plan

tested locally  
