### PR TITLE
Fix the zip file related tests

### DIFF
--- a/apps/photos/tests/zip-file-reading.test.ts
+++ b/apps/photos/tests/zip-file-reading.test.ts
@@ -6,6 +6,10 @@ import { getFileNameSize } from '@ente/shared/logging/web';
 import isElectron from 'is-electron';
 import { getImportSuggestion } from 'utils/upload';
 
+// This was for used to verify that converting from the browser readable stream
+// to the node readable stream correctly handles files that align on the 4 MB
+// data boundary. This expects a zip file containing random files of various
+// sizes starting from 1M to 20M.
 export const testZipFileReading = async () => {
     try {
         if (!isElectron()) {
@@ -73,6 +77,8 @@ export const testZipFileReading = async () => {
     }
 };
 
+// This was used when fixing a bug around handling a zip file that has a photo
+// at the root.
 export const testZipWithRootFileReadingTest = async () => {
     try {
         if (!isElectron()) {

--- a/apps/photos/tests/zip-file-reading.test.ts
+++ b/apps/photos/tests/zip-file-reading.test.ts
@@ -1,5 +1,5 @@
 import { DataStream } from 'types/upload';
-import ImportService from 'services/importService';
+import ElectronAPIs from '@ente/shared/electron';
 import { FILE_READER_CHUNK_SIZE, PICKED_UPLOAD_TYPE } from 'constants/upload';
 import { getFileStream, getElectronFileStream } from 'services/readerService';
 import { getFileNameSize } from '@ente/shared/logging/web';
@@ -17,12 +17,12 @@ export const testZipFileReading = async () => {
                 'upload test failed NEXT_PUBLIC_FILE_READING_TEST_ZIP_PATH missing'
             );
         }
-        const files = await ImportService.getElectronFilesFromGoogleZip(
+        const files = await ElectronAPIs.getElectronFilesFromGoogleZip(
             process.env.NEXT_PUBLIC_FILE_READING_TEST_ZIP_PATH
         );
         if (!files?.length) {
             throw Error(
-                `testZipFileReading Check failed ❌ 
+                `testZipFileReading Check failed ❌
                 No files selected`
             );
         }
@@ -84,7 +84,7 @@ export const testZipWithRootFileReadingTest = async () => {
                 'upload test failed NEXT_PUBLIC_ZIP_WITH_ROOT_FILE_PATH missing'
             );
         }
-        const files = await ImportService.getElectronFilesFromGoogleZip(
+        const files = await ElectronAPIs.getElectronFilesFromGoogleZip(
             process.env.NEXT_PUBLIC_ZIP_WITH_ROOT_FILE_PATH
         );
 


### PR DESCRIPTION
These functions (e.g. getElectronFilesFromGoogleZip) look to have been moved from `importService` to `ElectronAPIs` in commit 86d61060b752b2c68e8eabd58cb6ec45c4637175, perhaps the test did not get updated.

Verified that the test runs now from the desktop app.
