### PR TITLE
Deploy auth from the same repository (#1599)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# This script is run by the Cloudflare Pages integration when deploying the apps
+# in this repository. The app to build is decided based on the the value of the
+# CF_PAGES_BRANCH environment variable.
+#
+# Ref: https://developers.cloudflare.com/pages/how-to/build-commands-branches/
+#
+# The CF Pages configuration is set to use `out/` as the build output directory,
+# so once we're done building we copy the app specific output to `out/`.
+
+set -o errexit
+set -o xtrace
+
+rm -rf out
+
+if test "$CF_PAGES_BRANCH" = "auth-release"
+then
+    yarn export:auth
+    cp -R apps/auth/out .
+else
+    yarn export:photos
+    cp -R apps/photos/out .
+fi


### PR DESCRIPTION
This backports [#1599](https://github.com/ente-io/photos-web/pull/1599) into the auth-release branch, so that we can deploy the auth app from the same CF pages project without doing a full release.

(It wasn't clear to me how to backport this, I wrote my notes on this here - https://mrmr.io/n/cherry-pick-pr)