### PR TITLE
Reintroduce perhaps accidentally deleted line related to passkeys

### DIFF
--- a/apps/accounts/src/pages/passkeys/flow/index.tsx
+++ b/apps/accounts/src/pages/passkeys/flow/index.tsx
@@ -49,6 +49,7 @@ const PasskeysFlow = () => {
             }
         }
 
+        let pkg = CLIENT_PACKAGE_NAMES.get(APPS.PHOTOS);
         if (redirectURL.protocol === 'enteauth:') {
             pkg = CLIENT_PACKAGE_NAMES.get(APPS.AUTH);
         } else if (redirectURL.hostname.startsWith('accounts')) {


### PR DESCRIPTION
I'm not sure if this was intentional, but it looks like the initialization of `pkg` was accidentally deleted in e3019b6a40cea841270124effe9ebcbb35c1f263.
