### PR TITLE
Further prune .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,21 +4,9 @@ node_modules/
 # Next.js
 .next/
 out/
-.vercel
-.turbo/
 
-# misc
+# macOS
 .DS_Store
-tsconfig.tsbuildinfo
 
-# debug
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-
-# local env files
+# Local env files
 .env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local


### PR DESCRIPTION
Prune down the gitignore list to the remove gitignored files that were needed at some point, but are not needed now.

@ua741 @httpjamesm this might require you to run `git clean -dxf` on your local checkout once, since you might have leftover files from earlier (they'll not get recreated after this point)

